### PR TITLE
Fix reverse-proxy HTTPS redirect loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Reverse-proxy deployments no longer loop on HTTPS redirects when TLS terminates before Caddy (#20)
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/Caddyfile
+++ b/Caddyfile
@@ -23,6 +23,8 @@
 	}
 
 	handle {
-		reverse_proxy app:4000
+		reverse_proxy app:4000 {
+			header_up X-Forwarded-Proto https
+		}
 	}
 }

--- a/compose.dokploy.yml
+++ b/compose.dokploy.yml
@@ -71,7 +71,9 @@ configs:
         }
 
         handle {
-          reverse_proxy app:4000
+          reverse_proxy app:4000 {
+            header_up X-Forwarded-Proto https
+          }
         }
       }
 

--- a/test/deployment_config.test.mjs
+++ b/test/deployment_config.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+test('Caddy forwards the external request scheme to Phoenix', () => {
+  const caddyfile = readFileSync(new URL('../Caddyfile', import.meta.url), 'utf8');
+  const dokployCompose = readFileSync(new URL('../compose.dokploy.yml', import.meta.url), 'utf8');
+
+  assert.match(caddyfile, /header_up\s+X-Forwarded-Proto\s+https/);
+  assert.match(dokployCompose, /header_up\s+X-Forwarded-Proto\s+https/);
+});


### PR DESCRIPTION
## Summary
- Forward the external HTTPS scheme from both shipped Caddy configs to the Phoenix app.
- Add a regression test that checks the root Caddyfile and Dokploy inline Caddy config.
- Add an Unreleased changelog entry for #20.

Fixes #20.

## Reproduction
- Before the fix, `node --test test/deployment_config.test.mjs` failed because neither config set `X-Forwarded-Proto` for the app upstream.

## Verification
- `node --test test/deployment_config.test.mjs`
- `docker compose -f compose.dokploy.yml config --quiet`
- `docker compose -f compose.yml config --quiet`

## Risk
- Low: only app reverse-proxy headers are changed; tile and overpass handlers are untouched.