### PR TITLE
Make Overpass diff updates opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Overpass diff updates are now opt-in so POIs can serve after an initial import without waiting on Geofabrik catch-up (#27)
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/compose.yml
+++ b/compose.yml
@@ -139,7 +139,7 @@ services:
       # wiktorn/overpass-api needs OSM-XML+bzip2; the sidecar produces this
       # from the active PBF on every apply (data/osm/current.osm.bz2).
       OVERPASS_PLANET_URL: file:///osm/current.osm.bz2
-      OVERPASS_DIFF_URL: ${OVERPASS_DIFF_URL:-https://download.geofabrik.de/europe/germany-updates/}
+      OVERPASS_DIFF_URL: ${OVERPASS_DIFF_URL:-}
       OVERPASS_RULES_LOAD: 10
       OVERPASS_COMPRESSION: lz4
     volumes:

--- a/test/deployment_config.test.mjs
+++ b/test/deployment_config.test.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+test('Overpass diff updates are opt-in by default', () => {
+  const compose = readFileSync(new URL('../compose.yml', import.meta.url), 'utf8');
+
+  assert.match(compose, /OVERPASS_DIFF_URL:\s+\$\{OVERPASS_DIFF_URL:-\}/);
+});


### PR DESCRIPTION
## Summary
- Default `OVERPASS_DIFF_URL` to empty in `compose.yml`, matching the Dokploy compose default.
- Add a regression test that keeps Overpass diff updates opt-in by default.
- Add an Unreleased changelog entry for #27.

Fixes #27.

## Reproduction
- Before the fix, `node --test test/deployment_config.test.mjs` failed because `compose.yml` defaulted `OVERPASS_DIFF_URL` to a Geofabrik updates URL.

## Verification
- `node --test test/deployment_config.test.mjs`
- `docker compose -f compose.yml config --quiet`

## Risk
- Low: existing users can still opt into diffs by setting `OVERPASS_DIFF_URL`; the default startup path no longer blocks on diff catch-up.