### PR TITLE
Cap Valhalla worker threads by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Valhalla now starts with a safe default worker cap and file-descriptor limit on multi-core hosts (#24)
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/compose.yml
+++ b/compose.yml
@@ -120,10 +120,15 @@ services:
       build_admins: "True"
       build_elevation: ${BUILD_ELEVATION:-False}
       use_tiles_ignore_pbf: "False"
+      server_threads: ${VALHALLA_THREADS:-4}
     volumes:
       - ./data/valhalla:/custom_files
       - ./data/srtm:/custom_files/elevation_data
       - ./data/osm:/osm:ro
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
     restart: unless-stopped
 
   overpass:

--- a/test/deployment_config.test.mjs
+++ b/test/deployment_config.test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+test('Valhalla has a safe worker cap and nofile limit by default', () => {
+  const compose = readFileSync(new URL('../compose.yml', import.meta.url), 'utf8');
+
+  assert.match(compose, /server_threads:\s+\$\{VALHALLA_THREADS:-4\}/);
+  assert.match(compose, /ulimits:\n\s+nofile:\n\s+soft:\s+1048576\n\s+hard:\s+1048576/);
+});


### PR DESCRIPTION
## Summary
- Add a safe default `server_threads` cap for Valhalla via `VALHALLA_THREADS`.
- Add a high `nofile` ulimit to the Valhalla service.
- Add a regression test for the compose defaults and an Unreleased changelog entry.

Fixes #24.

## Reproduction
- Before the fix, `node --test test/deployment_config.test.mjs` failed because `compose.yml` did not set `server_threads` or a `nofile` ulimit for Valhalla.

## Verification
- `node --test test/deployment_config.test.mjs`
- `docker compose -f compose.yml config --quiet`

## Risk
- Low: users can still override worker count with `VALHALLA_THREADS`; the default avoids nproc-sized worker pools on many-core hosts.