### PR TITLE
Keep Dokploy Overpass optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Dokploy's minimal compose file no longer starts or exposes Overpass by default; the Overpass service and `/overpass` proxy are now commented out together as optional poster-sidecar configuration.
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/compose.dokploy.yml
+++ b/compose.dokploy.yml
@@ -61,14 +61,14 @@ configs:
           header @pmtiles Content-Type application/octet-stream
         }
 
-        # Overpass for the maptoposter sidecar. handle_path strips /overpass so
-        # OSMnx's /api/interpreter reaches the overpass root. Unique alias for
-        # the same dokploy-network collision reason noted below.
+        # Optional Overpass proxy for the maptoposter sidecar. Uncomment this
+        # together with the `overpass` service below. handle_path strips
+        # /overpass so OSMnx's /api/interpreter reaches the overpass root.
         # ⚠️ PUBLIC via Traefik — restrict to the sidecar's egress before use,
         # e.g. add `@ovp remote_ip A.B.C.D/32` then `reverse_proxy @ovp ...`.
-        handle_path /overpass/* {
-          reverse_proxy atlas-overpass:80
-        }
+        # handle_path /overpass/* {
+        #   reverse_proxy atlas-overpass:80
+        # }
 
         handle {
           reverse_proxy app:4000
@@ -173,28 +173,29 @@ services:
   #   restart: unless-stopped
   #   networks: [atlas]
   #
-  # Overpass for the maptoposter poster sidecar (uncommented = Cloud poster
-  # backend). ⚠️ PLANET sizing: the DB built from a planet PBF is large
-  # (hundreds of GB of disk; ingest is RAM-hungry) — provision the host first.
-  overpass:
-    image: wiktorn/overpass-api:v0.7.62.11
-    environment:
-      OVERPASS_META: ${OVERPASS_META:-no}
-      OVERPASS_MODE: init
-      # current.osm.bz2 must be the PLANET in OSM-XML+bz2, staged by the app's
-      # apply step. Posters tolerate stale data, so diff updates are OFF by
-      # default (static snapshot); re-import periodically instead.
-      OVERPASS_PLANET_URL: file:///osm/current.osm.bz2
-      OVERPASS_DIFF_URL: ${OVERPASS_DIFF_URL:-}
-      OVERPASS_RULES_LOAD: 10
-      OVERPASS_COMPRESSION: lz4
-    volumes:
-      - atlas_overpass:/db
-      - atlas_osm:/osm:ro
-    restart: unless-stopped
-    networks:
-      atlas:
-        aliases: [atlas-overpass]
+  # Overpass for the maptoposter poster sidecar (uncomment = Cloud poster
+  # backend, and uncomment the /overpass proxy above). ⚠️ PLANET sizing: the DB
+  # built from a planet PBF is large (hundreds of GB of disk; ingest is
+  # RAM-hungry) — provision the host first.
+  # overpass:
+  #   image: wiktorn/overpass-api:v0.7.62.11
+  #   environment:
+  #     OVERPASS_META: ${OVERPASS_META:-no}
+  #     OVERPASS_MODE: init
+  #     # current.osm.bz2 must be the PLANET in OSM-XML+bz2, staged by the app's
+  #     # apply step. Posters tolerate stale data, so diff updates are OFF by
+  #     # default (static snapshot); re-import periodically instead.
+  #     OVERPASS_PLANET_URL: file:///osm/current.osm.bz2
+  #     OVERPASS_DIFF_URL: ${OVERPASS_DIFF_URL:-}
+  #     OVERPASS_RULES_LOAD: 10
+  #     OVERPASS_COMPRESSION: lz4
+  #   volumes:
+  #     - atlas_overpass:/db
+  #     - atlas_osm:/osm:ro
+  #   restart: unless-stopped
+  #   networks:
+  #     atlas:
+  #       aliases: [atlas-overpass]
   #
   # otp:
   #   image: opentripplanner/opentripplanner:2.10.0_2026-05-18T08-51

--- a/test/deployment_config.test.mjs
+++ b/test/deployment_config.test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+test('Dokploy minimal compose does not enable Overpass by default', () => {
+  const compose = readFileSync(new URL('../compose.dokploy.yml', import.meta.url), 'utf8');
+
+  assert.doesNotMatch(compose, /^\s{8}handle_path \/overpass\/\* \{/m);
+  assert.doesNotMatch(compose, /^\s{2}overpass:\s*$/m);
+});


### PR DESCRIPTION
## Summary
Keeps Dokploy's minimal compose setup limited to `app` and `caddy`. Prevents the optional Overpass poster-sidecar service and `/overpass` proxy from starting or being exposed unless the operator explicitly enables both blocks.

## Changes
- Comments out the inline Caddy `/overpass` proxy in `compose.dokploy.yml`
- Comments out the Dokploy `overpass` service so the minimal setup matches the deployment notes
- Adds a Node test that guards against re-enabling Overpass in the minimal Dokploy compose
- Adds an unreleased changelog entry for the Dokploy fix

## Testing
- Run `node --test test/deployment_config.test.mjs` — confirms Dokploy minimal compose does not enable Overpass by default
- Run `docker compose -f compose.dokploy.yml config --quiet` — confirms the compose file remains valid

## Linked Issues
Closes #21
