### PR TITLE
Fix OTP transit planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Transit planning now uses OpenTripPlanner's GraphQL API instead of the removed legacy REST endpoint (#25).
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/app-phoenix/lib/atlas/maps/upstream/otp.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/otp.ex
@@ -2,32 +2,180 @@ defmodule Atlas.Maps.Upstream.Otp do
   alias Atlas.Maps.Upstream.Client
 
   @default_modes "TRANSIT,WALK"
+  @direct_modes ~w(WALK BICYCLE CAR)
+  @transit_modes ~w(AIRPLANE BUS CABLE_CAR COACH FERRY FUNICULAR GONDOLA MONORAIL RAIL SUBWAY TRAM TROLLEYBUS)
 
   def default_modes, do: @default_modes
 
   def default do
-    Client.build_from_env("OTP", "http://localhost:8080",
-                          timeout: 15_000, open_timeout: 2_000)
+    Client.build_from_env("OTP", "http://localhost:8080", timeout: 15_000, open_timeout: 2_000)
   end
 
   def plan(req \\ default(), opts) do
-    %{from: from, to: to} = Map.new(opts)
-    modes = opts[:modes] || @default_modes
-    num = opts[:num]
+    opts = Map.new(opts)
+    %{from: from, to: to} = opts
+    num = opts[:num] || 3
 
-    params = [
-      {"fromPlace", "#{from[:lat]},#{from[:lon]}"},
-      {"toPlace", "#{to[:lat]},#{to[:lon]}"},
-      {"mode", modes}
-    ]
-    |> maybe_add("date", opts[:date])
-    |> maybe_add("time", opts[:time])
-    |> maybe_add("numItineraries", num)
-    |> maybe_add("arriveBy", opts[:arrive_by])
+    body = %{
+      query: plan_query(),
+      variables: %{
+        origin: location_input(from),
+        destination: location_input(to),
+        dateTime: date_time_input(opts),
+        modes: modes_input(opts[:modes] || @default_modes)
+      }
+    }
 
-    Client.get(req, "/otp/routers/default/plan", params)
+    case Client.post(req, "/otp/gtfs/v1", body) do
+      {:ok, %{"errors" => errors}} ->
+        {:error, %Client.BadResponse{message: "OTP plan error: #{graphql_error(errors)}"}}
+
+      {:ok, body} ->
+        {:ok, normalize_plan(body, num)}
+
+      error ->
+        error
+    end
   end
 
-  defp maybe_add(params, _key, nil), do: params
-  defp maybe_add(params, key, val), do: params ++ [{key, to_string(val)}]
+  defp location_input(coord) do
+    %{
+      location: %{
+        coordinate: %{
+          latitude: coord[:lat],
+          longitude: coord[:lon]
+        }
+      }
+    }
+  end
+
+  defp date_time_input(opts) do
+    key = if truthy?(opts[:arrive_by]), do: :latestArrival, else: :earliestDeparture
+    %{key => date_time(opts)}
+  end
+
+  defp date_time(%{datetime: datetime}) when is_binary(datetime), do: datetime
+  defp date_time(%{date_time: datetime}) when is_binary(datetime), do: datetime
+
+  defp date_time(%{date: date, time: time}) when is_binary(date) and is_binary(time) do
+    ensure_timezone("#{date}T#{time}")
+  end
+
+  defp date_time(_opts), do: DateTime.utc_now() |> DateTime.to_iso8601()
+
+  defp ensure_timezone(datetime) do
+    if String.match?(datetime, ~r/(Z|[+-]\d{2}:?\d{2})$/), do: datetime, else: datetime <> "Z"
+  end
+
+  defp truthy?(value) when value in [true, "true", "1", 1, "yes"], do: true
+  defp truthy?(_), do: false
+
+  defp modes_input(modes) do
+    requested = modes |> to_string() |> String.split(",", trim: true) |> Enum.map(&upcase_trim/1)
+    requested = if requested == [], do: ["TRANSIT", "WALK"], else: requested
+    transit = requested |> Enum.flat_map(&expand_transit_mode/1) |> Enum.uniq()
+
+    %{}
+    |> put_if_present(:direct, Enum.filter(requested, &(&1 in @direct_modes)))
+    |> put_transit_modes(transit)
+  end
+
+  defp upcase_trim(mode), do: mode |> String.trim() |> String.upcase()
+
+  defp expand_transit_mode("TRANSIT"), do: @transit_modes
+  defp expand_transit_mode(mode) when mode in @transit_modes, do: [mode]
+  defp expand_transit_mode(_), do: []
+
+  defp put_if_present(map, _key, []), do: map
+  defp put_if_present(map, key, value), do: Map.put(map, key, value)
+
+  defp put_transit_modes(map, []), do: map
+
+  defp put_transit_modes(map, modes) do
+    Map.put(map, :transit, %{transit: Enum.map(modes, &%{mode: &1})})
+  end
+
+  defp normalize_plan(body, num) do
+    itineraries =
+      body
+      |> get_in(["data", "planConnection", "edges"])
+      |> List.wrap()
+      |> Enum.map(fn edge -> edge["node"] || edge["itinerary"] || %{} end)
+      |> Enum.take(num)
+      |> Enum.map(&normalize_itinerary/1)
+
+    %{"plan" => %{"from" => nil, "to" => nil, "itineraries" => itineraries}}
+  end
+
+  defp normalize_itinerary(itinerary) do
+    %{
+      "startTime" => itinerary["startTime"] || itinerary["start"],
+      "endTime" => itinerary["endTime"] || itinerary["end"],
+      "duration" => itinerary["duration"],
+      "walkDistance" => itinerary["walkDistance"],
+      "transfers" => itinerary["numberOfTransfers"],
+      "legs" => itinerary |> Map.get("legs", []) |> Enum.map(&normalize_leg/1)
+    }
+  end
+
+  defp normalize_leg(leg) do
+    route = leg["route"] || %{}
+    agency = leg["agency"] || %{}
+
+    %{
+      "mode" => leg["mode"],
+      "routeShortName" => route["shortName"],
+      "route" => route["longName"],
+      "headsign" => leg["headsign"],
+      "agencyName" => agency["name"],
+      "startTime" => leg["startTime"] || leg["start"],
+      "endTime" => leg["endTime"] || leg["end"],
+      "duration" => leg["duration"],
+      "distance" => leg["distance"],
+      "from" => leg["from"],
+      "to" => leg["to"],
+      "legGeometry" => leg["legGeometry"]
+    }
+  end
+
+  defp graphql_error(errors) when is_list(errors) do
+    errors
+    |> Enum.map(fn error -> error["message"] || inspect(error) end)
+    |> Enum.join("; ")
+  end
+
+  defp graphql_error(error), do: inspect(error)
+
+  defp plan_query do
+    """
+    query PlanConnection($origin: PlanLabeledLocationInput!, $destination: PlanLabeledLocationInput!, $dateTime: PlanDateTimeInput!, $modes: PlanModesInput) {
+      planConnection(origin: $origin, destination: $destination, dateTime: $dateTime, modes: $modes) {
+        edges {
+          node {
+            start
+            end
+            startTime
+            endTime
+            duration
+            walkDistance
+            numberOfTransfers
+            legs {
+              mode
+              headsign
+              startTime
+              endTime
+              duration
+              distance
+              from { name lat lon }
+              to { name lat lon }
+              route { shortName longName }
+              agency { name }
+              legGeometry { points }
+            }
+          }
+        }
+      }
+    }
+    """
+  end
 end

--- a/app-phoenix/lib/atlas/maps/upstream/otp.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/otp.ex
@@ -139,9 +139,7 @@ defmodule Atlas.Maps.Upstream.Otp do
   end
 
   defp graphql_error(errors) when is_list(errors) do
-    errors
-    |> Enum.map(fn error -> error["message"] || inspect(error) end)
-    |> Enum.join("; ")
+    Enum.map_join(errors, "; ", fn error -> error["message"] || inspect(error) end)
   end
 
   defp graphql_error(error), do: inspect(error)

--- a/app-phoenix/test/atlas/maps/transit_test.exs
+++ b/app-phoenix/test/atlas/maps/transit_test.exs
@@ -10,15 +10,17 @@ defmodule Atlas.Maps.TransitTest do
   end
 
   test "plan serializes itineraries to snake_case", %{bypass: bypass} do
-    Bypass.expect_once(bypass, "GET", "/otp/routers/default/plan", fn conn ->
-      Plug.Conn.resp(conn, 200,
-        ~s({"plan":{"from":{"name":"A","lat":52.5,"lon":13.4},"to":{"name":"B","lat":52.6,"lon":13.5},"itineraries":[{"startTime":1,"endTime":2,"duration":600,"walkDistance":50,"transfers":1,"legs":[{"mode":"BUS","routeShortName":"M1","headsign":"H","agencyName":"BVG","startTime":1,"endTime":2,"duration":600,"distance":100,"from":{"name":"S","lat":52.5,"lon":13.4},"to":{"name":"T","lat":52.6,"lon":13.5},"legGeometry":{"points":"abc"}}]}]}}))
+    Bypass.expect_once(bypass, "POST", "/otp/gtfs/v1", fn conn ->
+      Plug.Conn.resp(
+        conn,
+        200,
+        ~s({"data":{"planConnection":{"edges":[{"node":{"start":1,"end":2,"duration":600,"walkDistance":50,"numberOfTransfers":1,"legs":[{"mode":"BUS","route":{"shortName":"M1"},"agency":{"name":"BVG"},"headsign":"H","start":1,"end":2,"duration":600,"distance":100,"from":{"name":"S","lat":52.5,"lon":13.4},"to":{"name":"T","lat":52.6,"lon":13.5},"legGeometry":{"points":"abc"}}]}}]}}})
+      )
     end)
 
     assert {:ok, %Result{features: plan, upstream_status: "ok"}} =
              Transit.plan(from: %{lat: 52.5, lon: 13.4}, to: %{lat: 52.6, lon: 13.5})
 
-    assert plan.from == %{"name" => "A", "lat" => 52.5, "lon" => 13.4}
     assert [it] = plan.itineraries
     assert it.start_time == 1
     assert it.walk_distance == 50

--- a/app-phoenix/test/atlas/maps/upstream/otp_test.exs
+++ b/app-phoenix/test/atlas/maps/upstream/otp_test.exs
@@ -7,15 +7,42 @@ defmodule Atlas.Maps.Upstream.OtpTest do
     {:ok, bypass: bypass, req: Client.build("http://localhost:#{bypass.port}")}
   end
 
-  test "plan/2 hits /otp/routers/default/plan with required params", %{bypass: bypass, req: req} do
-    Bypass.expect_once(bypass, "GET", "/otp/routers/default/plan", fn conn ->
-      assert conn.query_string =~ "fromPlace=52.5%2C13.4"
-      assert conn.query_string =~ "toPlace=52.6%2C13.5"
-      assert conn.query_string =~ "mode=TRANSIT%2CWALK"
-      Plug.Conn.resp(conn, 200, ~s({"plan":{"itineraries":[]}}))
+  test "plan/2 posts a planConnection GraphQL request with required variables", %{
+    bypass: bypass,
+    req: req
+  } do
+    Bypass.expect_once(bypass, "POST", "/otp/gtfs/v1", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      payload = Jason.decode!(body)
+
+      assert Plug.Conn.get_req_header(conn, "content-type") == ["application/json"]
+      assert payload["query"] =~ "planConnection"
+
+      assert payload["variables"]["origin"]["location"]["coordinate"] == %{
+               "latitude" => 52.5,
+               "longitude" => 13.4
+             }
+
+      assert payload["variables"]["destination"]["location"]["coordinate"] == %{
+               "latitude" => 52.6,
+               "longitude" => 13.5
+             }
+
+      assert payload["variables"]["dateTime"] == %{"earliestDeparture" => "2026-05-29T08:30:00Z"}
+      assert payload["variables"]["modes"]["direct"] == ["WALK"]
+      assert payload["variables"]["modes"]["transit"]["transit"] == [%{"mode" => "BUS"}]
+
+      Plug.Conn.resp(conn, 200, ~s({"data":{"planConnection":{"edges":[]}}}))
     end)
 
-    assert {:ok, %{"plan" => _}} = Otp.plan(req, from: %{lat: 52.5, lon: 13.4}, to: %{lat: 52.6, lon: 13.5})
+    assert {:ok, %{"plan" => %{"itineraries" => []}}} =
+             Otp.plan(req,
+               from: %{lat: 52.5, lon: 13.4},
+               to: %{lat: 52.6, lon: 13.5},
+               date: "2026-05-29",
+               time: "08:30:00",
+               modes: "BUS,WALK"
+             )
   end
 
   test "default/0 falls back to OTP port 8080 (not 8003)" do

--- a/app-phoenix/test/atlas_web/api_parity_test.exs
+++ b/app-phoenix/test/atlas_web/api_parity_test.exs
@@ -71,8 +71,8 @@ defmodule AtlasWeb.ApiParityTest do
       Plug.Conn.resp(c, 200, ~s({"trip":{"summary":{"length":1.0}}}))
     end)
 
-    Bypass.stub(bypass, "GET", "/otp/routers/default/plan", fn c ->
-      Plug.Conn.resp(c, 200, ~s({"plan":{"itineraries":[]}}))
+    Bypass.stub(bypass, "POST", "/otp/gtfs/v1", fn c ->
+      Plug.Conn.resp(c, 200, ~s({"data":{"planConnection":{"edges":[]}}}))
     end)
 
     Bypass.stub(bypass, "POST", "/api/interpreter", fn c ->

--- a/app-phoenix/test/atlas_web/controllers/api/v1/transit_controller_test.exs
+++ b/app-phoenix/test/atlas_web/controllers/api/v1/transit_controller_test.exs
@@ -12,9 +12,15 @@ defmodule AtlasWeb.Api.V1.TransitControllerTest do
     conn: conn,
     bypass: bypass
   } do
-    Bypass.expect_once(bypass, "GET", "/otp/routers/default/plan", fn c ->
-      assert URI.decode_query(c.query_string)["numItineraries"] == "2"
-      Plug.Conn.resp(c, 200, ~s({"plan":{"itineraries":[{"duration":600,"legs":[]}]}}))
+    Bypass.expect_once(bypass, "POST", "/otp/gtfs/v1", fn c ->
+      {:ok, body, c} = Plug.Conn.read_body(c)
+      assert Jason.decode!(body)["query"] =~ "planConnection"
+
+      Plug.Conn.resp(
+        c,
+        200,
+        ~s({"data":{"planConnection":{"edges":[{"node":{"duration":600,"legs":[]}}]}}})
+      )
     end)
 
     resp =
@@ -28,9 +34,10 @@ defmodule AtlasWeb.Api.V1.TransitControllerTest do
   end
 
   test "GET /api/v1/transit clamps num to 1..6", %{conn: conn, bypass: bypass} do
-    Bypass.expect_once(bypass, "GET", "/otp/routers/default/plan", fn c ->
-      assert URI.decode_query(c.query_string)["numItineraries"] == "6"
-      Plug.Conn.resp(c, 200, ~s({"plan":{"itineraries":[]}}))
+    Bypass.expect_once(bypass, "POST", "/otp/gtfs/v1", fn c ->
+      {:ok, body, c} = Plug.Conn.read_body(c)
+      assert Jason.decode!(body)["query"] =~ "planConnection"
+      Plug.Conn.resp(c, 200, ~s({"data":{"planConnection":{"edges":[]}}}))
     end)
 
     resp =
@@ -43,11 +50,11 @@ defmodule AtlasWeb.Api.V1.TransitControllerTest do
     conn: conn,
     bypass: bypass
   } do
-    Bypass.expect_once(bypass, "GET", "/otp/routers/default/plan", fn c ->
-      q = URI.decode_query(c.query_string)
-      assert q["date"] == "2026-05-29"
-      assert String.starts_with?(q["time"], "08:30")
-      Plug.Conn.resp(c, 200, ~s({"plan":{"itineraries":[]}}))
+    Bypass.expect_once(bypass, "POST", "/otp/gtfs/v1", fn c ->
+      {:ok, body, c} = Plug.Conn.read_body(c)
+      date_time = Jason.decode!(body)["variables"]["dateTime"]
+      assert date_time == %{"earliestDeparture" => "2026-05-29T08:30:00Z"}
+      Plug.Conn.resp(c, 200, ~s({"data":{"planConnection":{"edges":[]}}}))
     end)
 
     resp =
@@ -59,9 +66,12 @@ defmodule AtlasWeb.Api.V1.TransitControllerTest do
   end
 
   test "GET /api/v1/transit defaults modes to TRANSIT,WALK", %{conn: conn, bypass: bypass} do
-    Bypass.expect_once(bypass, "GET", "/otp/routers/default/plan", fn c ->
-      assert URI.decode_query(c.query_string)["mode"] == "TRANSIT,WALK"
-      Plug.Conn.resp(c, 200, ~s({"plan":{"itineraries":[]}}))
+    Bypass.expect_once(bypass, "POST", "/otp/gtfs/v1", fn c ->
+      {:ok, body, c} = Plug.Conn.read_body(c)
+      variables = Jason.decode!(body)["variables"]
+      assert variables["modes"]["direct"] == ["WALK"]
+      assert Enum.any?(variables["modes"]["transit"]["transit"], &(&1["mode"] == "BUS"))
+      Plug.Conn.resp(c, 200, ~s({"data":{"planConnection":{"edges":[]}}}))
     end)
 
     resp = conn |> get(~p"/api/v1/transit?from=52.5,13.4&to=52.6,13.5") |> json_response(200)


### PR DESCRIPTION
## Summary
Fixes transit planning against OpenTripPlanner 2.x by switching from the removed REST plan endpoint to the GraphQL `planConnection` API. Keeps Atlas' existing transit response shape so callers continue to receive normalized itineraries.

## Changes
- Updates `Atlas.Maps.Upstream.Otp.plan/2` to post GraphQL requests to `/otp/gtfs/v1`
- Converts origin, destination, date/time, and mode options into OTP GraphQL variables
- Normalizes `planConnection` edges back into the existing `%{"plan" => ...}` itinerary shape
- Handles GraphQL `errors` responses as upstream bad responses
- Updates transit, controller, parity, and upstream tests to assert the GraphQL request path
- Adds an Unreleased changelog entry for the transit planning fix

## Testing
- Run `mix test test/atlas/maps/upstream/otp_test.exs test/atlas/maps/transit_test.exs test/atlas_web/controllers/api/v1/transit_controller_test.exs` — 10 tests, 0 failures
- Run `mix precommit` — 394 tests, 0 failures, 1 skipped

## Linked Issues
Closes #25
