### PR TITLE
Honour PUID/PGID so the app boots on NAS hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,14 @@
 #   will tell you when this is the case).
 # DOCKER_GID=999
 
+# PUID/PGID: uid:gid the app drops to, and the owner it gives ./data/app.
+#   Defaults to 65534:65534 (nobody). Set these when the host data dir belongs
+#   to someone else — Unraid's nobody:users is 99:100, Synology/QNAP differ —
+#   otherwise the app cannot write its DB or generated secret key. The
+#   container reports the mismatch and exits rather than restart-looping.
+# PUID=99
+# PGID=100
+
 # Region selection (ISO-2 country code; see Geofabrik for valid extracts)
 COUNTRY_CODE=de
 PBF_URL=https://download.geofabrik.de/europe/germany-latest.osm.pbf

--- a/.env.example
+++ b/.env.example
@@ -26,11 +26,13 @@
 #   will tell you when this is the case).
 # DOCKER_GID=999
 
-# PUID/PGID: uid:gid the app drops to, and the owner it gives ./data/app.
+# PUID/PGID: uid:gid the app drops to, and the owner it gives ./data/app plus
+#   the region dirs ./data/{osm,gtfs,otp,tiles}. Sibling services under ./data
+#   keep their own ownership (whosonfirst runs as ${UID:-1001}).
 #   Defaults to 65534:65534 (nobody). Set these when the host data dir belongs
 #   to someone else — Unraid's nobody:users is 99:100, Synology/QNAP differ —
 #   otherwise the app cannot write its DB or generated secret key. The
-#   container reports the mismatch and exits rather than restart-looping.
+#   container names the offending directories and exits rather than looping.
 # PUID=99
 # PGID=100
 

--- a/.github/workflows/test-phoenix.yml
+++ b/.github/workflows/test-phoenix.yml
@@ -34,3 +34,6 @@ jobs:
       # --include parity activates the byte-diff gate against the committed
       # Rails goldens, enforcing API parity with the legacy Rails app.
       - run: mix test --include parity
+      # The release entrypoint is shell, so it is covered by a shell test that
+      # stubs id/chown/setpriv rather than by ExUnit.
+      - run: sh test/scripts/docker_entrypoint_test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- The app no longer crash-loops when the data dir is owned by another uid: `PUID`/`PGID` are honoured, the entrypoint takes ownership before dropping privileges, and an unwritable dir reports a clear error instead of a bare `Permission denied` (#23)
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,16 +22,30 @@ docker compose up -d
 
 That's it — no `.env` file required. The app auto-generates a `SECRET_KEY_BASE` on first boot (persisted to `data/app/.secret_key_base`) and stores its data in a local SQLite file under `data/app/`.
 
-One knob you may need: the in-app control plane talks to the host docker
-socket as the `nobody` user via the `DOCKER_GID` supplementary group
-(default `999`). If the Settings panel shows a "Control plane degraded"
-banner, set it to the socket's group and recreate the container:
+Two knobs you may need:
+
+**`DOCKER_GID`** — the in-app control plane talks to the host docker socket as
+the `nobody` user via this supplementary group (default `999`). If the Settings
+panel shows a "Control plane degraded" banner, set it to the socket's group and
+recreate the container:
 
 ```bash
 # Linux
 echo "DOCKER_GID=$(stat -c %g /var/run/docker.sock)" >> .env
 # macOS (OrbStack / Docker Desktop) — the socket maps as gid 0
 echo "DOCKER_GID=0" >> .env
+docker compose up -d app
+```
+
+**`PUID` / `PGID`** — the uid:gid Atlas runs as, and the owner it gives `./data`
+on boot (default `65534:65534`, i.e. `nobody`). On a NAS the appdata share
+usually belongs to someone else — Unraid uses `99:100`, Synology and QNAP
+differ — and Atlas will refuse to start with a message naming the directory
+rather than looping on "Permission denied". Set them to the share's owner:
+
+```bash
+stat -c '%u %g' ./data          # whoever owns it on the host
+printf 'PUID=99\nPGID=100\n' >> .env
 docker compose up -d app
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,18 @@ echo "DOCKER_GID=0" >> .env
 docker compose up -d app
 ```
 
-**`PUID` / `PGID`** — the uid:gid Atlas runs as, and the owner it gives `./data`
-on boot (default `65534:65534`, i.e. `nobody`). On a NAS the appdata share
-usually belongs to someone else — Unraid uses `99:100`, Synology and QNAP
-differ — and Atlas will refuse to start with a message naming the directory
-rather than looping on "Permission denied". Set them to the share's owner:
+**`PUID` / `PGID`** — the uid:gid Atlas runs as, and the owner it gives its own
+data directories on boot: `./data/app` plus the region dirs `./data/{osm,gtfs,otp,tiles}`
+(default `65534:65534`, i.e. `nobody`). Other services under `./data` keep their
+own ownership — `whosonfirst`, for instance, runs as `${UID:-1001}`.
+
+On a NAS the appdata share usually belongs to someone else — Unraid uses
+`99:100`, Synology and QNAP differ — and Atlas will refuse to start with a
+message naming the directories rather than looping on "Permission denied". Set
+them to the share's owner:
 
 ```bash
-stat -c '%u %g' ./data          # whoever owns it on the host
+stat -c '%u %g' ./data/app      # whoever owns it on the host
 printf 'PUID=99\nPGID=100\n' >> .env
 docker compose up -d app
 ```

--- a/app-phoenix/Dockerfile
+++ b/app-phoenix/Dockerfile
@@ -68,10 +68,15 @@ RUN mkdir -p /data && chown nobody:nogroup /data
 COPY --from=builder --chown=nobody:nogroup /app/_build/prod/rel/atlas ./
 
 # Starts as root only long enough to take ownership of the bind-mounted data
-# dir, then drops to PUID:PGID (default 65534:65534, i.e. the previous
+# dirs, then drops to PUID:PGID (default 65534:65534, i.e. the previous
 # `nobody`) via setpriv. Override `user:` in compose to skip that entirely —
-# the entrypoint then just verifies the dir is writable and reports clearly if
-# it is not, instead of looping on "Permission denied".
+# the entrypoint then just verifies the dirs are writable and reports clearly
+# if they are not, instead of looping on "Permission denied".
+#
+# NOTE: `docker compose exec app <cmd>` bypasses this ENTRYPOINT and therefore
+# runs as root. Prefer `docker compose exec -u 65534:65534 app …` (or your
+# PUID:PGID) for anything that writes to /data, so it does not leave
+# root-owned files the app cannot rewrite until the next restart.
 EXPOSE 4000
 ENTRYPOINT ["/app/bin/docker-entrypoint"]
 CMD ["/app/bin/server"]

--- a/app-phoenix/Dockerfile
+++ b/app-phoenix/Dockerfile
@@ -39,7 +39,7 @@ FROM debian:bookworm-20260518-slim AS runner
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
       libstdc++6 openssl libncurses6 locales ca-certificates \
-      osmium-tool curl gnupg && \
+      osmium-tool curl gnupg util-linux && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
@@ -64,9 +64,14 @@ ENV LANG=en_US.UTF-8 \
 
 WORKDIR /app
 RUN mkdir -p /data && chown nobody:nogroup /data
-USER nobody:nogroup
 
 COPY --from=builder --chown=nobody:nogroup /app/_build/prod/rel/atlas ./
 
+# Starts as root only long enough to take ownership of the bind-mounted data
+# dir, then drops to PUID:PGID (default 65534:65534, i.e. the previous
+# `nobody`) via setpriv. Override `user:` in compose to skip that entirely —
+# the entrypoint then just verifies the dir is writable and reports clearly if
+# it is not, instead of looping on "Permission denied".
 EXPOSE 4000
+ENTRYPOINT ["/app/bin/docker-entrypoint"]
 CMD ["/app/bin/server"]

--- a/app-phoenix/rel/overlays/bin/docker-entrypoint
+++ b/app-phoenix/rel/overlays/bin/docker-entrypoint
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Make the bind-mounted data dir usable before the app touches it.
+#
+# Docker creates a bind-mount source as root:root, and NAS hosts (Unraid,
+# Synology, QNAP) own it as their own "nobody" — neither of which matches the
+# image's uid. Without this the app fails on /data/.secret_key_base with a
+# bare "Permission denied" and restart-loops, which reads like a corrupt key
+# rather than an ownership mismatch.
+#
+# Started as root: take ownership of the data dir, then drop to PUID:PGID
+# (default 65534:65534) keeping the supplementary groups, so the control plane
+# still reaches the docker socket group from compose's `group_add`.
+# Started as non-root (compose `user:`): nothing to chown — just check the dir
+# is usable and say so clearly if it is not.
+set -eu
+
+DATA_DIR="${ATLAS_DATA_DIR:-/data}"
+PUID="${PUID:-65534}"
+PGID="${PGID:-65534}"
+
+mkdir -p "$DATA_DIR" 2>/dev/null || true
+
+if [ "$(id -u)" = "0" ]; then
+  chown -R "$PUID:$PGID" "$DATA_DIR" ||
+    echo "atlas: warning: could not chown $DATA_DIR to $PUID:$PGID" >&2
+
+  # Carry root's supplementary groups across the drop; compose adds the docker
+  # socket's gid there and the control plane needs it.
+  groups="$(id -G | tr ' ' ',')"
+
+  exec setpriv \
+    --reuid="$PUID" \
+    --regid="$PGID" \
+    --groups="$groups" \
+    -- "$@"
+fi
+
+if [ ! -w "$DATA_DIR" ]; then
+  cat >&2 <<EOF
+atlas: $DATA_DIR is not writable by uid $(id -u).
+
+The data dir holds the SQLite database and the generated secret key, so the
+app cannot boot without it. Either:
+
+  * let the container fix it for you — start it as root (drop any \`user:\`
+    override) and set PUID/PGID to the host owner of ./data/app, e.g.
+        PUID=99
+        PGID=100
+  * or chown it on the host to the uid this container runs as:
+        chown -R $(id -u):$(id -g) ./data/app
+EOF
+  exit 1
+fi
+
+exec "$@"

--- a/app-phoenix/rel/overlays/bin/docker-entrypoint
+++ b/app-phoenix/rel/overlays/bin/docker-entrypoint
@@ -14,12 +14,16 @@
 # dirs are usable and say so clearly if they are not.
 set -eu
 
-# Follow DATABASE_PATH so an operator who relocates the SQLite file gets that
-# directory prepared too; ATLAS_DATA_DIR overrides both (and is what the test
-# harness uses). bin/server writes .secret_key_base into the same directory.
-DATA_DIR="${ATLAS_DATA_DIR:-$(dirname "${DATABASE_PATH:-/data/atlas.sqlite3}")}"
+DATA_DIR="${ATLAS_DATA_DIR:-/data}"
 PUID="${PUID:-65534}"
 PGID="${PGID:-65534}"
+
+# The database and the generated secret key are relocatable independently of
+# each other, and bin/server defaults the key to /data regardless of
+# DATABASE_PATH — so prepare whichever directories they actually resolve to
+# rather than assuming they share one.
+DB_DIR="$(dirname "${DATABASE_PATH:-$DATA_DIR/atlas.sqlite3}")"
+SECRET_DIR="$(dirname "${SECRET_KEY_BASE_PATH:-/data/.secret_key_base}")"
 
 # The app also writes region data, GTFS bundles, OTP graphs and tile packs
 # through /work/data (see Atlas.Control.RegionApplier and TilesDownloader).
@@ -28,26 +32,34 @@ PGID="${PGID:-65534}"
 WORK_DATA_DIR="${ATLAS_WORK_DATA_DIR:-/work/data}"
 
 usable_dirs() {
-  for d in "$DATA_DIR" "$WORK_DATA_DIR/osm" "$WORK_DATA_DIR/gtfs" \
-           "$WORK_DATA_DIR/otp" "$WORK_DATA_DIR/tiles"; do
+  for d in "$DATA_DIR" "$DB_DIR" "$SECRET_DIR" "$WORK_DATA_DIR/osm" \
+           "$WORK_DATA_DIR/gtfs" "$WORK_DATA_DIR/otp" "$WORK_DATA_DIR/tiles"; do
     [ -d "$d" ] && echo "$d"
-  done
+  done | awk '!seen[$0]++'
 }
 
+# $1 = newline-separated list of unusable dirs, $2 = uid the app will run as,
+# $3 = gid the app will run as.
 explain_unwritable() {
-  cat >&2 <<EOF
-atlas: $1 is not writable by uid $(id -u).
+  {
+    echo "atlas: these directories are not writable by uid $2:"
+    echo "$1" | sed 's/^/  /'
+    cat <<EOF
 
 Atlas stores its database, generated secret key and region data there, so it
 cannot boot without write access. Either:
 
   * let the container fix it for you — start it as root (drop any \`user:\`
-    override) and set PUID/PGID to the host owner of ./data, e.g.
+    override) and set PUID/PGID to the host owner of ./data/app, e.g.
         PUID=99
         PGID=100
-  * or chown it on the host to the uid this container runs as:
-        chown -R $(id -u):$(id -g) ./data
+  * or chown just those paths on the host to $2:$3, e.g.
+        chown -R $2:$3 ./data/app ./data/osm ./data/gtfs ./data/otp ./data/tiles
+
+    Chown ./data as a whole only if you know what else lives there — sibling
+    services such as whosonfirst run as their own uid and would break.
 EOF
+  } >&2
 }
 
 mkdir -p "$DATA_DIR" 2>/dev/null || true
@@ -55,22 +67,31 @@ mkdir -p "$DATA_DIR" 2>/dev/null || true
 if [ "$(id -u)" = "0" ]; then
   chown_failed=""
   for d in $(usable_dirs); do
-    chown -R "$PUID:$PGID" "$d" 2>/dev/null || chown_failed="$d"
+    chown -R "$PUID:$PGID" "$d" 2>/dev/null ||
+      chown_failed="$(printf '%s\n%s' "$chown_failed" "$d" | sed '/^$/d')"
   done
 
   # A failed chown is NOT survivable: exec'ing anyway lands the app in exactly
   # the "Permission denied" restart loop this entrypoint exists to prevent.
   # Common on NFS root_squash exports, userns-remap and rootless Podman.
   if [ -n "$chown_failed" ]; then
-    echo "atlas: could not chown $chown_failed to $PUID:$PGID" >&2
-    explain_unwritable "$chown_failed"
+    explain_unwritable "$chown_failed" "$PUID" "$PGID"
     exit 1
   fi
 
-  # Carry the docker socket group across the drop, but NOT root's gid 0 —
-  # keeping it would leave the "dropped" process with root group access for
-  # its whole lifetime.
+  # Carry the docker socket group across the drop, but not root's own gid 0 —
+  # keeping that would leave the "dropped" process with root group access for
+  # its whole lifetime. DOCKER_GID is re-added explicitly afterwards, because
+  # on macOS (OrbStack / Docker Desktop) the socket really is gid 0 and the
+  # README tells operators to set DOCKER_GID=0.
   groups="$(id -G | tr ' ' '\n' | grep -vx 0 | grep -vx "$PGID" | paste -sd, -)"
+
+  if [ -n "${DOCKER_GID:-}" ] && [ "$DOCKER_GID" != "$PGID" ]; then
+    case ",$groups," in
+      *",$DOCKER_GID,"*) ;;
+      *) groups="$(printf '%s,%s' "$DOCKER_GID" "$groups" | sed 's/,$//')" ;;
+    esac
+  fi
 
   if [ -n "$groups" ]; then
     group_args="--groups=$groups"
@@ -85,11 +106,14 @@ if [ "$(id -u)" = "0" ]; then
     -- "$@"
 fi
 
+unwritable=""
 for d in $(usable_dirs); do
-  if [ ! -w "$d" ]; then
-    explain_unwritable "$d"
-    exit 1
-  fi
+  [ -w "$d" ] || unwritable="$(printf '%s\n%s' "$unwritable" "$d" | sed '/^$/d')"
 done
+
+if [ -n "$unwritable" ]; then
+  explain_unwritable "$unwritable" "$(id -u)" "$(id -g)"
+  exit 1
+fi
 
 exec "$@"

--- a/app-phoenix/rel/overlays/bin/docker-entrypoint
+++ b/app-phoenix/rel/overlays/bin/docker-entrypoint
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Make the bind-mounted data dir usable before the app touches it.
+# Make the bind-mounted data dirs usable before the app touches them.
 #
 # Docker creates a bind-mount source as root:root, and NAS hosts (Unraid,
 # Synology, QNAP) own it as their own "nobody" — neither of which matches the
@@ -7,49 +7,89 @@
 # bare "Permission denied" and restart-loops, which reads like a corrupt key
 # rather than an ownership mismatch.
 #
-# Started as root: take ownership of the data dir, then drop to PUID:PGID
-# (default 65534:65534) keeping the supplementary groups, so the control plane
-# still reaches the docker socket group from compose's `group_add`.
-# Started as non-root (compose `user:`): nothing to chown — just check the dir
-# is usable and say so clearly if it is not.
+# Started as root: take ownership of the data dirs, then drop to PUID:PGID
+# (default 65534:65534) keeping the docker socket group from compose's
+# `group_add` so the control plane still works.
+# Started as non-root (compose `user:`): nothing to chown — just check the
+# dirs are usable and say so clearly if they are not.
 set -eu
 
-DATA_DIR="${ATLAS_DATA_DIR:-/data}"
+# Follow DATABASE_PATH so an operator who relocates the SQLite file gets that
+# directory prepared too; ATLAS_DATA_DIR overrides both (and is what the test
+# harness uses). bin/server writes .secret_key_base into the same directory.
+DATA_DIR="${ATLAS_DATA_DIR:-$(dirname "${DATABASE_PATH:-/data/atlas.sqlite3}")}"
 PUID="${PUID:-65534}"
 PGID="${PGID:-65534}"
+
+# The app also writes region data, GTFS bundles, OTP graphs and tile packs
+# through /work/data (see Atlas.Control.RegionApplier and TilesDownloader).
+# Those are separate bind mounts, so chowning /data alone leaves "Save & apply"
+# broken with a degraded-control-plane banner.
+WORK_DATA_DIR="${ATLAS_WORK_DATA_DIR:-/work/data}"
+
+usable_dirs() {
+  for d in "$DATA_DIR" "$WORK_DATA_DIR/osm" "$WORK_DATA_DIR/gtfs" \
+           "$WORK_DATA_DIR/otp" "$WORK_DATA_DIR/tiles"; do
+    [ -d "$d" ] && echo "$d"
+  done
+}
+
+explain_unwritable() {
+  cat >&2 <<EOF
+atlas: $1 is not writable by uid $(id -u).
+
+Atlas stores its database, generated secret key and region data there, so it
+cannot boot without write access. Either:
+
+  * let the container fix it for you — start it as root (drop any \`user:\`
+    override) and set PUID/PGID to the host owner of ./data, e.g.
+        PUID=99
+        PGID=100
+  * or chown it on the host to the uid this container runs as:
+        chown -R $(id -u):$(id -g) ./data
+EOF
+}
 
 mkdir -p "$DATA_DIR" 2>/dev/null || true
 
 if [ "$(id -u)" = "0" ]; then
-  chown -R "$PUID:$PGID" "$DATA_DIR" ||
-    echo "atlas: warning: could not chown $DATA_DIR to $PUID:$PGID" >&2
+  chown_failed=""
+  for d in $(usable_dirs); do
+    chown -R "$PUID:$PGID" "$d" 2>/dev/null || chown_failed="$d"
+  done
 
-  # Carry root's supplementary groups across the drop; compose adds the docker
-  # socket's gid there and the control plane needs it.
-  groups="$(id -G | tr ' ' ',')"
+  # A failed chown is NOT survivable: exec'ing anyway lands the app in exactly
+  # the "Permission denied" restart loop this entrypoint exists to prevent.
+  # Common on NFS root_squash exports, userns-remap and rootless Podman.
+  if [ -n "$chown_failed" ]; then
+    echo "atlas: could not chown $chown_failed to $PUID:$PGID" >&2
+    explain_unwritable "$chown_failed"
+    exit 1
+  fi
+
+  # Carry the docker socket group across the drop, but NOT root's gid 0 —
+  # keeping it would leave the "dropped" process with root group access for
+  # its whole lifetime.
+  groups="$(id -G | tr ' ' '\n' | grep -vx 0 | grep -vx "$PGID" | paste -sd, -)"
+
+  if [ -n "$groups" ]; then
+    group_args="--groups=$groups"
+  else
+    group_args="--clear-groups"
+  fi
 
   exec setpriv \
     --reuid="$PUID" \
     --regid="$PGID" \
-    --groups="$groups" \
+    "$group_args" \
     -- "$@"
 fi
 
-if [ ! -w "$DATA_DIR" ]; then
-  cat >&2 <<EOF
-atlas: $DATA_DIR is not writable by uid $(id -u).
-
-The data dir holds the SQLite database and the generated secret key, so the
-app cannot boot without it. Either:
-
-  * let the container fix it for you — start it as root (drop any \`user:\`
-    override) and set PUID/PGID to the host owner of ./data/app, e.g.
-        PUID=99
-        PGID=100
-  * or chown it on the host to the uid this container runs as:
-        chown -R $(id -u):$(id -g) ./data/app
-EOF
-  exit 1
-fi
+for d in $(usable_dirs); do
+  if [ ! -w "$d" ]; then
+    explain_unwritable "$d"
+    exit 1
+  fi
+done
 
 exec "$@"

--- a/app-phoenix/test/scripts/docker_entrypoint_test.sh
+++ b/app-phoenix/test/scripts/docker_entrypoint_test.sh
@@ -54,8 +54,11 @@ setup_sandbox() {
   SANDBOX="$(mktemp -d)"
   BIN="$SANDBOX/bin"
   DATA="$SANDBOX/data"
+  WORK_DATA="$SANDBOX/work-data"
   LOG="$SANDBOX/calls.log"
   mkdir -p "$BIN" "$DATA"
+  # The region pipeline's bind mounts, which the app writes through /work/data.
+  mkdir -p "$WORK_DATA/osm" "$WORK_DATA/gtfs" "$WORK_DATA/otp" "$WORK_DATA/tiles"
   : > "$LOG"
 
   cat > "$BIN/id" <<EOF
@@ -90,7 +93,7 @@ teardown_sandbox() { rm -rf "$SANDBOX"; }
 # Run the entrypoint in the sandbox. Echoes stdout+stderr; sets RUN_STATUS.
 run_entrypoint() {
   set +e
-  RUN_OUTPUT="$(PATH="$BIN:$PATH" ATLAS_DATA_DIR="$DATA" "$@" \
+  RUN_OUTPUT="$(PATH="$BIN:$PATH" ATLAS_DATA_DIR="$DATA" ATLAS_WORK_DATA_DIR="$WORK_DATA" "$@" \
     "$ENTRYPOINT" /bin/echo "app-started" 2>&1)"
   RUN_STATUS=$?
   set -e
@@ -108,6 +111,43 @@ assert_contains "drops to the matching gid" "$RUN_CALLS" "--regid=65534"
 assert_contains "preserves the docker socket group" "$RUN_CALLS" "--groups=999"
 teardown_sandbox
 
+printf '\n== the region pipeline bind mounts are prepared too ==\n'
+setup_sandbox 0 "0 999"
+run_entrypoint env
+for sub in osm gtfs otp tiles; do
+  assert_contains "chowns /work/data/$sub" "$RUN_CALLS" "$WORK_DATA/$sub"
+done
+teardown_sandbox
+
+printf '\n== relocating DATABASE_PATH still prepares the secret-key dir ==\n'
+setup_sandbox 0 "0 999"
+mkdir -p "$DATA/db"
+run_entrypoint env DATABASE_PATH="$DATA/db/atlas.sqlite3" SECRET_KEY_BASE_PATH="$DATA/.secret_key_base"
+assert_contains "prepares the relocated database dir" "$RUN_CALLS" "$DATA/db"
+assert_contains "still prepares the secret-key dir" "$RUN_CALLS" "chown -R 65534:65534 $DATA
+"
+teardown_sandbox
+
+printf '\n== DOCKER_GID=0 (macOS/OrbStack) survives the gid-0 strip ==\n'
+setup_sandbox 0 "0"
+run_entrypoint env DOCKER_GID=0
+assert_contains "keeps the socket group the operator asked for" "$RUN_CALLS" "--groups=0"
+assert_not_contains "does not discard it as root's own gid" "$RUN_CALLS" "--clear-groups"
+teardown_sandbox
+
+printf '\n== remediation advice names the app data dir, not the whole ./data tree ==\n'
+setup_sandbox 65534 "65534 999"
+chmod 500 "$DATA"
+run_entrypoint env
+chown_line="$(printf '%s' "$RUN_OUTPUT" | grep 'chown -R' | head -1)"
+assert_contains "the suggested chown targets the app data dir" "$chown_line" "./data/app"
+assert_not_contains "the suggested chown does not target the whole tree" \
+  "$(printf '%s' "$chown_line" | sed 's|\./data/[a-z]*||g')" "./data"
+assert_contains "warns about sibling services before widening it" "$RUN_OUTPUT" "whosonfirst"
+assert_contains "names PUID as the remedy" "$RUN_OUTPUT" "PUID"
+chmod 700 "$DATA"
+teardown_sandbox
+
 printf '\n== root, but chown fails (NFS root_squash / userns-remap) ==\n'
 setup_sandbox 0 "0 999"
 cat > "$BIN/chown" <<EOF
@@ -116,11 +156,26 @@ echo "chown \$*" >> "$LOG"
 exit 1
 EOF
 chmod +x "$BIN/chown"
-run_entrypoint env
+run_entrypoint env PUID=99 PGID=100
 assert_status "refuses to start rather than crash-looping" "$RUN_STATUS" 1
 assert_contains "explains the data dir is unusable" "$RUN_OUTPUT" "not writable"
 assert_contains "points at the PUID/PGID knob" "$RUN_OUTPUT" "PUID"
+assert_contains "reports the uid the app will run as, not root" "$RUN_OUTPUT" "99"
+assert_not_contains "does not advise chowning to root" "$RUN_OUTPUT" "chown -R 0:0"
 assert_not_contains "does not start the app" "$RUN_OUTPUT" "app-started"
+teardown_sandbox
+
+printf '\n== every unwritable mount is named, not just the last one ==\n'
+setup_sandbox 0 "0 999"
+cat > "$BIN/chown" <<EOF
+#!/bin/sh
+echo "chown \$*" >> "$LOG"
+exit 1
+EOF
+chmod +x "$BIN/chown"
+run_entrypoint env
+assert_contains "names the app data dir" "$RUN_OUTPUT" "$DATA"
+assert_contains "names a failing region dir too" "$RUN_OUTPUT" "$WORK_DATA/osm"
 teardown_sandbox
 
 printf '\n== privilege drop does not carry root gid 0 forward ==\n'

--- a/app-phoenix/test/scripts/docker_entrypoint_test.sh
+++ b/app-phoenix/test/scripts/docker_entrypoint_test.sh
@@ -105,7 +105,36 @@ assert_contains "execs the wrapped command" "$RUN_OUTPUT" "app-started"
 assert_contains "chowns the data dir to the default uid" "$RUN_CALLS" "65534:65534"
 assert_contains "drops privileges with setpriv" "$RUN_CALLS" "--reuid=65534"
 assert_contains "drops to the matching gid" "$RUN_CALLS" "--regid=65534"
-assert_contains "preserves the docker socket group" "$RUN_CALLS" "--groups=0,999"
+assert_contains "preserves the docker socket group" "$RUN_CALLS" "--groups=999"
+teardown_sandbox
+
+printf '\n== root, but chown fails (NFS root_squash / userns-remap) ==\n'
+setup_sandbox 0 "0 999"
+cat > "$BIN/chown" <<EOF
+#!/bin/sh
+echo "chown \$*" >> "$LOG"
+exit 1
+EOF
+chmod +x "$BIN/chown"
+run_entrypoint env
+assert_status "refuses to start rather than crash-looping" "$RUN_STATUS" 1
+assert_contains "explains the data dir is unusable" "$RUN_OUTPUT" "not writable"
+assert_contains "points at the PUID/PGID knob" "$RUN_OUTPUT" "PUID"
+assert_not_contains "does not start the app" "$RUN_OUTPUT" "app-started"
+teardown_sandbox
+
+printf '\n== privilege drop does not carry root gid 0 forward ==\n'
+setup_sandbox 0 "0 999"
+run_entrypoint env
+assert_not_contains "gid 0 is not in the supplementary groups" "$RUN_CALLS" "--groups=0,"
+assert_contains "the docker socket group survives" "$RUN_CALLS" "--groups=999"
+teardown_sandbox
+
+printf '\n== root with no extra groups beyond gid 0 ==\n'
+setup_sandbox 0 "0"
+run_entrypoint env
+assert_status "still starts" "$RUN_STATUS" 0
+assert_contains "clears supplementary groups rather than passing an empty list" "$RUN_CALLS" "--clear-groups"
 teardown_sandbox
 
 printf '\n== running as root with PUID/PGID (Unraid/Synology) ==\n'

--- a/app-phoenix/test/scripts/docker_entrypoint_test.sh
+++ b/app-phoenix/test/scripts/docker_entrypoint_test.sh
@@ -39,6 +39,19 @@ assert_not_contains() {
   fi
 }
 
+# Exact whole-line match. Use this instead of assert_contains whenever the
+# expected string is a complete line: grep -F treats a newline inside the
+# pattern as a pattern separator, so an embedded one silently matches anything.
+assert_line() {
+  tests=$((tests + 1))
+  if printf '%s\n' "$2" | grep -qxF -- "$3"; then
+    pass "$1"
+  else
+    fail "$1" "expected a line exactly equal to: $3"
+    printf '    actual: %s\n' "$2"
+  fi
+}
+
 assert_status() {
   tests=$((tests + 1))
   if [ "$2" -eq "$3" ]; then
@@ -119,13 +132,16 @@ for sub in osm gtfs otp tiles; do
 done
 teardown_sandbox
 
-printf '\n== relocating DATABASE_PATH still prepares the secret-key dir ==\n'
+printf '\n== database and secret-key dirs are resolved independently ==\n'
 setup_sandbox 0 "0 999"
-mkdir -p "$DATA/db"
-run_entrypoint env DATABASE_PATH="$DATA/db/atlas.sqlite3" SECRET_KEY_BASE_PATH="$DATA/.secret_key_base"
-assert_contains "prepares the relocated database dir" "$RUN_CALLS" "$DATA/db"
-assert_contains "still prepares the secret-key dir" "$RUN_CALLS" "chown -R 65534:65534 $DATA
-"
+# Three genuinely distinct locations, so each one's contribution is visible:
+# bin/server defaults the secret key to /data no matter where the DB lives.
+mkdir -p "$SANDBOX/dbdir" "$SANDBOX/secretdir"
+run_entrypoint env \
+  DATABASE_PATH="$SANDBOX/dbdir/atlas.sqlite3" \
+  SECRET_KEY_BASE_PATH="$SANDBOX/secretdir/.secret_key_base"
+assert_line "prepares the relocated database dir" "$RUN_CALLS" "chown -R 65534:65534 $SANDBOX/dbdir"
+assert_line "prepares the secret-key dir too" "$RUN_CALLS" "chown -R 65534:65534 $SANDBOX/secretdir"
 teardown_sandbox
 
 printf '\n== DOCKER_GID=0 (macOS/OrbStack) survives the gid-0 strip ==\n'

--- a/app-phoenix/test/scripts/docker_entrypoint_test.sh
+++ b/app-phoenix/test/scripts/docker_entrypoint_test.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+# Tests rel/overlays/bin/docker-entrypoint without needing root or a daemon:
+# `id`, `chown` and `setpriv` are replaced by stubs on PATH that record how
+# they were called.
+set -eu
+
+SCRIPT_DIR="$(cd -P -- "$(dirname -- "$0")" && pwd)"
+ENTRYPOINT="$SCRIPT_DIR/../../rel/overlays/bin/docker-entrypoint"
+
+failures=0
+tests=0
+
+fail() {
+  failures=$((failures + 1))
+  printf '  ✗ %s\n' "$1"
+  [ $# -gt 1 ] && printf '    %s\n' "$2"
+  return 0
+}
+
+pass() { printf '  ✓ %s\n' "$1"; }
+
+assert_contains() {
+  tests=$((tests + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    pass "$1"
+  else
+    fail "$1" "expected to contain: $3"
+    printf '    actual: %s\n' "$2"
+  fi
+}
+
+assert_not_contains() {
+  tests=$((tests + 1))
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    fail "$1" "expected NOT to contain: $3"
+    printf '    actual: %s\n' "$2"
+  else
+    pass "$1"
+  fi
+}
+
+assert_status() {
+  tests=$((tests + 1))
+  if [ "$2" -eq "$3" ]; then
+    pass "$1"
+  else
+    fail "$1" "expected exit $3, got $2"
+  fi
+}
+
+# Build a sandbox: stub bin dir on PATH, a fake data dir, and a recorded log.
+# $1 = uid reported by `id -u`; $2 = groups reported by `id -G`
+setup_sandbox() {
+  SANDBOX="$(mktemp -d)"
+  BIN="$SANDBOX/bin"
+  DATA="$SANDBOX/data"
+  LOG="$SANDBOX/calls.log"
+  mkdir -p "$BIN" "$DATA"
+  : > "$LOG"
+
+  cat > "$BIN/id" <<EOF
+#!/bin/sh
+case "\$1" in
+  -u) echo "$1" ;;
+  -G) echo "$2" ;;
+  *)  echo "$1" ;;
+esac
+EOF
+
+  cat > "$BIN/chown" <<EOF
+#!/bin/sh
+echo "chown \$*" >> "$LOG"
+EOF
+
+  # setpriv records its args, then runs the trailing command so the rest of
+  # the entrypoint still executes under the "dropped" identity.
+  cat > "$BIN/setpriv" <<EOF
+#!/bin/sh
+echo "setpriv \$*" >> "$LOG"
+while [ "\$1" != "--" ] && [ \$# -gt 0 ]; do shift; done
+[ "\$1" = "--" ] && shift
+exec "\$@"
+EOF
+
+  chmod +x "$BIN/id" "$BIN/chown" "$BIN/setpriv"
+}
+
+teardown_sandbox() { rm -rf "$SANDBOX"; }
+
+# Run the entrypoint in the sandbox. Echoes stdout+stderr; sets RUN_STATUS.
+run_entrypoint() {
+  set +e
+  RUN_OUTPUT="$(PATH="$BIN:$PATH" ATLAS_DATA_DIR="$DATA" "$@" \
+    "$ENTRYPOINT" /bin/echo "app-started" 2>&1)"
+  RUN_STATUS=$?
+  set -e
+  RUN_CALLS="$(cat "$LOG")"
+}
+
+printf '\n== running as root ==\n'
+setup_sandbox 0 "0 999"
+run_entrypoint env
+assert_status "starts the app" "$RUN_STATUS" 0
+assert_contains "execs the wrapped command" "$RUN_OUTPUT" "app-started"
+assert_contains "chowns the data dir to the default uid" "$RUN_CALLS" "65534:65534"
+assert_contains "drops privileges with setpriv" "$RUN_CALLS" "--reuid=65534"
+assert_contains "drops to the matching gid" "$RUN_CALLS" "--regid=65534"
+assert_contains "preserves the docker socket group" "$RUN_CALLS" "--groups=0,999"
+teardown_sandbox
+
+printf '\n== running as root with PUID/PGID (Unraid/Synology) ==\n'
+setup_sandbox 0 "0 999"
+run_entrypoint env PUID=99 PGID=100
+assert_status "starts the app" "$RUN_STATUS" 0
+assert_contains "chowns the data dir to PUID:PGID" "$RUN_CALLS" "chown -R 99:100"
+assert_contains "drops to PUID" "$RUN_CALLS" "--reuid=99"
+assert_contains "drops to PGID" "$RUN_CALLS" "--regid=100"
+teardown_sandbox
+
+printf '\n== already running as a non-root user (compose `user:`) ==\n'
+setup_sandbox 65534 "65534 999"
+run_entrypoint env
+assert_status "starts the app" "$RUN_STATUS" 0
+assert_contains "execs the wrapped command" "$RUN_OUTPUT" "app-started"
+assert_not_contains "does not try to chown" "$RUN_CALLS" "chown"
+assert_not_contains "does not try to drop privileges again" "$RUN_CALLS" "setpriv"
+teardown_sandbox
+
+printf '\n== non-root with an unwritable data dir (issue #23) ==\n'
+setup_sandbox 65534 "65534 999"
+chmod 500 "$DATA"
+run_entrypoint env
+assert_status "fails fast instead of crash-looping" "$RUN_STATUS" 1
+assert_contains "names the unwritable path" "$RUN_OUTPUT" "$DATA"
+assert_contains "explains it is an ownership problem" "$RUN_OUTPUT" "not writable"
+assert_contains "points at the PUID/PGID knob" "$RUN_OUTPUT" "PUID"
+assert_not_contains "does not start the app" "$RUN_OUTPUT" "app-started"
+chmod 700 "$DATA"
+teardown_sandbox
+
+printf '\n%s tests, %s failures\n' "$tests" "$failures"
+[ "$failures" -eq 0 ] || exit 1

--- a/compose.yml
+++ b/compose.yml
@@ -30,6 +30,10 @@ services:
       # 99:100) — set these there so the app can write its DB and secret key.
       PUID: ${PUID:-65534}
       PGID: ${PGID:-65534}
+      # Also readable by the entrypoint so the socket group survives the
+      # privilege drop — on macOS the socket is gid 0, which is otherwise
+      # stripped as root's own group.
+      DOCKER_GID: ${DOCKER_GID:-999}
       DATABASE_URL: ${DATABASE_URL:-}
       PHOTON_URL: http://photon:2322
       PLACEHOLDER_URL: http://placeholder:3000

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,11 @@ services:
       # SQLite by default. For Postgres set DATABASE_URL=postgres://... AND use
       # an image built with ATLAS_DB_ADAPTER=postgres.
       DATABASE_PATH: ${DATABASE_PATH:-/data/atlas.sqlite3}
+      # uid:gid the app runs as, and the owner it gives ./data/app on boot.
+      # Defaults to nobody. NAS hosts own the bind dir differently (Unraid:
+      # 99:100) — set these there so the app can write its DB and secret key.
+      PUID: ${PUID:-65534}
+      PGID: ${PGID:-65534}
       DATABASE_URL: ${DATABASE_URL:-}
       PHOTON_URL: http://photon:2322
       PLACEHOLDER_URL: http://placeholder:3000


### PR DESCRIPTION
Fixes #23.

## Problem

The image runs as `nobody` (uid 65534) and writes `.secret_key_base` plus its SQLite DB into the `./data/app` bind mount, but nothing ensures that host directory is writable by 65534. On Unraid / Synology / QNAP (where the dir belongs to a different uid) and on a fresh host (where Docker creates the bind source as `root:root`), the app crash-loops on:

```
cat: /data/.secret_key_base: Permission denied
```

which reads like a corrupt key rather than an ownership mismatch — and contradicts the quickstart's "that's it, no `.env` required".

## Change

A new `rel/overlays/bin/docker-entrypoint`:

- **Started as root** (the default): `chown -R` the data dir to `PUID:PGID` (default `65534:65534`, i.e. the previous `nobody`), then drop privileges with `setpriv`, carrying the supplementary groups across so the control plane keeps the docker socket group from compose's `group_add`.
- **Started as non-root** (compose `user:` override, the reporter's workaround): nothing to chown — verify the dir is writable and, if not, print an actionable error naming the path and both ways to fix it, then exit. No more restart loop on an opaque message.

`PUID`/`PGID` are plumbed through `compose.yml` and documented in `.env.example`.

## Notes

- `util-linux` is now installed explicitly rather than relying on `setpriv` being present in `debian:bookworm-slim`.
- Running as root by default is new, but the entrypoint always drops privileges before exec'ing the app; setting `user:` in compose still bypasses that path entirely.

## Tests

The entrypoint is shell, so it is covered by `test/scripts/docker_entrypoint_test.sh`, which stubs `id`, `chown` and `setpriv` on PATH and asserts on how they were called. Added as a step to the `test-phoenix` workflow.

```
19 tests, 0 failures
```

Covers: root defaults, root with `PUID`/`PGID`, supplementary-group preservation, the non-root passthrough, and the unwritable-dir diagnostic.

⚠️ **Not verified in a real container** — no Docker daemon was available while writing this, so the `setpriv` privilege-drop has only been exercised against stubs. Worth one real `docker compose up` on a NAS-like host before release.