### PR TITLE
Unbound the osmium convert and stop serving stale POI data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Region apply no longer stalls or silently serves stale POI data: the PBF→bz2 convert is no longer bounded by a 30-minute timeout, orphaned `.partial` files are swept, and a failed conversion fails the apply loudly instead of leaving overpass on a weeks-old snapshot (#34, #28)
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ## [Unreleased]
 
 ### Fixed
-- Region apply no longer stalls or silently serves stale POI data: the PBF→bz2 convert is no longer bounded by a 30-minute timeout, orphaned `.partial` files are swept, and a failed conversion fails the apply loudly instead of leaving overpass on a weeks-old snapshot (#34, #28)
+- Region apply no longer stalls or silently serves stale POI data: the PBF→bz2 convert is no longer bounded by a 30-minute wall-clock timeout (a genuinely hung osmium is now caught by a stall watchdog instead), orphaned `.partial` files are swept from `osm/`, `osm/sources/` and `gtfs/`, and a failed conversion fails the apply loudly instead of leaving overpass on a weeks-old snapshot (#34, #28). The convert now runs after OTP staging, so a broken overpass source no longer withholds fresh data from valhalla and OTP.
 
 ## [0.3.0] - 2026-06-10
 

--- a/app-phoenix/lib/atlas/control/osmium.ex
+++ b/app-phoenix/lib/atlas/control/osmium.ex
@@ -23,7 +23,7 @@ defmodule Atlas.Control.Osmium do
   """
   def merge(data_dir, sources, out) when is_list(sources) do
     args = ["merge"] ++ sources ++ ["-O", "-o", out]
-    GenServer.call(__MODULE__, {:osmium, data_dir, args}, :timer.minutes(30))
+    GenServer.call(__MODULE__, {:osmium, data_dir, args}, call_timeout())
   end
 
   @doc """
@@ -32,8 +32,18 @@ defmodule Atlas.Control.Osmium do
   """
   def convert_to_osm_bz2(data_dir, in_path, out_path) do
     args = ["cat", in_path, "-o", out_path, "-O", "-f", "osm.bz2"]
-    GenServer.call(__MODULE__, {:osmium, data_dir, args}, :timer.minutes(30))
+    GenServer.call(__MODULE__, {:osmium, data_dir, args}, call_timeout())
   end
+
+  @doc """
+  Client-side ceiling for an osmium invocation. Defaults to `:infinity`.
+
+  These are long-running external ports: bzip2 compression is effectively
+  single-threaded, so a country-scale `osmium cat -f osm.bz2` runs well past
+  an hour. A wall-clock ceiling kills it mid-write and strands a `.partial`,
+  so serialization — not a deadline — is what this GenServer is for.
+  """
+  def call_timeout, do: Application.get_env(:atlas, :osmium_timeout, :infinity)
 
   @impl true
   def init(opts) do

--- a/app-phoenix/lib/atlas/control/osmium.ex
+++ b/app-phoenix/lib/atlas/control/osmium.ex
@@ -47,20 +47,85 @@ defmodule Atlas.Control.Osmium do
 
   @impl true
   def init(opts) do
-    runner = Keyword.get(opts, :runner, &default_runner/3)
-    {:ok, %{runner: runner}}
+    {:ok,
+     %{
+       runner: Keyword.get(opts, :runner, &default_runner/3),
+       stall_timeout: Keyword.get(opts, :stall_timeout, stall_timeout()),
+       stall_poll: Keyword.get(opts, :stall_poll, :timer.seconds(30))
+     }}
   end
 
   @impl true
-  def handle_call({:osmium, data_dir, args}, _from, %{runner: runner} = state) do
+  def handle_call({:osmium, data_dir, args}, _from, state) do
+    task =
+      Task.async(fn ->
+        state.runner.("osmium", args, cd: data_dir, stderr_to_stdout: true)
+      end)
+
     reply =
-      case runner.("osmium", args, cd: data_dir, stderr_to_stdout: true) do
-        {output, 0} -> {:ok, output}
-        {output, code} -> {:error, code, output}
+      case await_with_watchdog(task, output_path(data_dir, args), state) do
+        {:ok, {output, 0}} -> {:ok, output}
+        {:ok, {output, code}} -> {:error, code, output}
+        {:error, :stalled, detail} -> {:error, :stalled, detail}
       end
 
     {:reply, reply, state}
   end
+
+  # osmium writes its output file steadily, so "the file stopped growing" is a
+  # far better death signal than a wall-clock deadline: a legitimately slow
+  # convert keeps growing for hours, while a wedged one flatlines immediately.
+  defp await_with_watchdog(task, out_path, state) do
+    do_await(task, out_path, state, size_of(out_path), 0)
+  end
+
+  defp do_await(task, out_path, state, last_size, stalled_for) do
+    case Task.yield(task, state.stall_poll) do
+      {:ok, result} ->
+        {:ok, result}
+
+      nil ->
+        size = size_of(out_path)
+
+        cond do
+          size > last_size ->
+            do_await(task, out_path, state, size, 0)
+
+          stalled_for + state.stall_poll >= state.stall_timeout ->
+            Task.shutdown(task, :brutal_kill)
+
+            {:error, :stalled,
+             "no progress on #{out_path} for #{div(state.stall_timeout, 1000)}s — killed"}
+
+          true ->
+            do_await(task, out_path, state, size, stalled_for + state.stall_poll)
+        end
+    end
+  end
+
+  defp size_of(nil), do: 0
+
+  defp size_of(path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} -> size
+      {:error, _} -> 0
+    end
+  end
+
+  # Both `merge` and `cat` name their destination right after `-o`.
+  defp output_path(data_dir, args) do
+    case Enum.drop_while(args, &(&1 != "-o")) do
+      ["-o", out | _] -> Path.expand(out, data_dir)
+      _ -> nil
+    end
+  end
+
+  @doc """
+  How long the output file may stop growing before the invocation is killed.
+  Defaults to 30 minutes; override with `:osmium_stall_timeout`.
+  """
+  def stall_timeout,
+    do: Application.get_env(:atlas, :osmium_stall_timeout, :timer.minutes(30))
 
   defp default_runner(cmd, args, opts), do: System.cmd(cmd, args, opts)
 end

--- a/app-phoenix/lib/atlas/control/osmium.ex
+++ b/app-phoenix/lib/atlas/control/osmium.ex
@@ -50,6 +50,7 @@ defmodule Atlas.Control.Osmium do
     {:ok,
      %{
        runner: Keyword.get(opts, :runner, &default_runner/3),
+       command: Keyword.get(opts, :command, "osmium"),
        stall_timeout: Keyword.get(opts, :stall_timeout, stall_timeout()),
        stall_poll: Keyword.get(opts, :stall_poll, :timer.seconds(30))
      }}
@@ -57,9 +58,11 @@ defmodule Atlas.Control.Osmium do
 
   @impl true
   def handle_call({:osmium, data_dir, args}, _from, state) do
+    owner = self()
+
     task =
       Task.async(fn ->
-        state.runner.("osmium", args, cd: data_dir, stderr_to_stdout: true)
+        state.runner.(state.command, args, cd: data_dir, stderr_to_stdout: true, report_to: owner)
       end)
 
     reply =
@@ -69,6 +72,7 @@ defmodule Atlas.Control.Osmium do
         {:error, :stalled, detail} -> {:error, :stalled, detail}
       end
 
+    flush_os_pid()
     {:reply, reply, state}
   end
 
@@ -92,14 +96,29 @@ defmodule Atlas.Control.Osmium do
             do_await(task, out_path, state, size, 0)
 
           stalled_for + state.stall_poll >= state.stall_timeout ->
-            Task.shutdown(task, :brutal_kill)
-
-            {:error, :stalled,
-             "no progress on #{out_path} for #{div(state.stall_timeout, 1000)}s — killed"}
+            terminate_stalled(task, out_path, state)
 
           true ->
             do_await(task, out_path, state, size, stalled_for + state.stall_poll)
         end
+    end
+  end
+
+  defp terminate_stalled(task, out_path, state) do
+    # Kill the OS process FIRST: tearing down the Task only drops the port
+    # owner, leaving osmium alive to keep writing into the data dir while the
+    # freed GenServer lets the next apply start a second one.
+    kill_os_process()
+
+    case Task.shutdown(task, :brutal_kill) do
+      # It finished inside the race window — honour the real result rather than
+      # discarding a completed multi-hour convert as stalled.
+      {:ok, result} ->
+        {:ok, result}
+
+      _ ->
+        {:error, :stalled,
+         "no progress on #{out_path} for #{div(state.stall_timeout, 1000)}s — killed"}
     end
   end
 
@@ -127,5 +146,60 @@ defmodule Atlas.Control.Osmium do
   def stall_timeout,
     do: Application.get_env(:atlas, :osmium_stall_timeout, :timer.minutes(30))
 
-  defp default_runner(cmd, args, opts), do: System.cmd(cmd, args, opts)
+  defp default_runner(cmd, args, opts), do: spawn_and_collect(cmd, args, opts)
+
+  @doc """
+  Run `cmd` through a port and block until it exits, returning
+  `{output, exit_status}` like `System.cmd/3`.
+
+  A port rather than `System.cmd/3` because the OS pid is knowable that way:
+  `System.cmd/3` gives no handle on the child, and tearing down the calling
+  process leaves it running. When `:report_to` is a pid it receives
+  `{:osmium_os_pid, os_pid}`, which is what lets the stall watchdog kill it.
+  """
+  def spawn_and_collect(cmd, args, opts) do
+    executable = System.find_executable(cmd) || cmd
+
+    port =
+      Port.open({:spawn_executable, executable}, [
+        :binary,
+        :exit_status,
+        :stderr_to_stdout,
+        :hide,
+        args: args,
+        cd: Keyword.fetch!(opts, :cd)
+      ])
+
+    with pid when is_pid(pid) <- opts[:report_to],
+         {:os_pid, os_pid} <- Port.info(port, :os_pid) do
+      send(pid, {:osmium_os_pid, os_pid})
+    end
+
+    collect_port(port, [])
+  end
+
+  defp collect_port(port, acc) do
+    receive do
+      {^port, {:data, chunk}} -> collect_port(port, [acc | chunk])
+      {^port, {:exit_status, status}} -> {IO.iodata_to_binary(acc), status}
+    end
+  end
+
+  defp kill_os_process do
+    receive do
+      {:osmium_os_pid, os_pid} ->
+        System.cmd("kill", ["-9", Integer.to_string(os_pid)], stderr_to_stdout: true)
+        :ok
+    after
+      0 -> :ok
+    end
+  end
+
+  defp flush_os_pid do
+    receive do
+      {:osmium_os_pid, _} -> flush_os_pid()
+    after
+      0 -> :ok
+    end
+  end
 end

--- a/app-phoenix/lib/atlas/control/osmium.ex
+++ b/app-phoenix/lib/atlas/control/osmium.ex
@@ -110,14 +110,16 @@ defmodule Atlas.Control.Osmium do
     # Kill the OS process FIRST: tearing down the Task only drops the port
     # owner, leaving osmium alive to keep writing into the data dir while the
     # freed GenServer lets the next apply start a second one.
-    kill_os_process()
+    killed? = kill_os_process()
 
-    case Task.shutdown(task, :brutal_kill) do
-      # It finished inside the race window — honour the real result rather than
-      # discarding a completed multi-hour convert as stalled.
-      {:ok, result} ->
+    case {killed?, Task.shutdown(task, :brutal_kill)} do
+      # Nothing was killed and it finished inside the race window — honour the
+      # real result rather than discarding a completed multi-hour convert.
+      {false, {:ok, result}} ->
         {:ok, result}
 
+      # If we SIGKILLed it, the task's own result is just the signal exit (137)
+      # racing us back. Report the stall we diagnosed, not the wound we caused.
       _ ->
         {:error, :stalled,
          "no progress on #{out_path} for #{div(state.stall_timeout, 1000)}s — killed"}
@@ -193,18 +195,19 @@ defmodule Atlas.Control.Osmium do
   # dependency. Failures are swallowed: losing the child is bad, but crashing
   # this GenServer is worse, since it sits under :rest_for_one and would take
   # the applier and the service supervisors down mid-apply.
+  # Returns true when a child was actually signalled.
   defp kill_os_process do
     receive do
       {:osmium_os_pid, os_pid} ->
         System.cmd("/bin/sh", ["-c", "kill -9 #{os_pid}"], stderr_to_stdout: true)
-        :ok
+        true
     after
-      0 -> :ok
+      0 -> false
     end
   rescue
     e ->
       Logger.warning("could not kill stalled osmium: #{Exception.message(e)}")
-      :ok
+      true
   end
 
   defp flush_os_pid do

--- a/app-phoenix/lib/atlas/control/osmium.ex
+++ b/app-phoenix/lib/atlas/control/osmium.ex
@@ -11,6 +11,8 @@ defmodule Atlas.Control.Osmium do
 
   use GenServer
 
+  require Logger
+
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
@@ -185,14 +187,24 @@ defmodule Atlas.Control.Osmium do
     end
   end
 
+  # Through `sh -c` on purpose: `System.cmd/3` execs directly, and the runner
+  # image (debian-slim) has no `kill` binary — that lives in procps, which is
+  # not installed. `kill` is a shell builtin, so this works with no new
+  # dependency. Failures are swallowed: losing the child is bad, but crashing
+  # this GenServer is worse, since it sits under :rest_for_one and would take
+  # the applier and the service supervisors down mid-apply.
   defp kill_os_process do
     receive do
       {:osmium_os_pid, os_pid} ->
-        System.cmd("kill", ["-9", Integer.to_string(os_pid)], stderr_to_stdout: true)
+        System.cmd("/bin/sh", ["-c", "kill -9 #{os_pid}"], stderr_to_stdout: true)
         :ok
     after
       0 -> :ok
     end
+  rescue
+    e ->
+      Logger.warning("could not kill stalled osmium: #{Exception.message(e)}")
+      :ok
   end
 
   defp flush_os_pid do

--- a/app-phoenix/lib/atlas/control/region_applier.ex
+++ b/app-phoenix/lib/atlas/control/region_applier.ex
@@ -7,7 +7,8 @@ defmodule Atlas.Control.RegionApplier do
     2. download GTFS bundles into `gtfs/` (failure is non-fatal)
     3. materialise `osm/current.osm.pbf` — relative symlink for one source,
        `osmium merge` via `.partial` + rename for several
-    4. convert to `osm/current.osm.bz2` for overpass (failure is non-fatal)
+    4. convert to `osm/current.osm.bz2` for overpass (fatal — a swallowed
+       failure would leave overpass importing a stale snapshot silently)
     5. stage OTP inputs (`otp/region.osm.pbf` + GTFS zips, drop `graph.obj`)
     6. `docker compose restart` the enabled ingest services
 
@@ -164,6 +165,7 @@ defmodule Atlas.Control.RegionApplier do
     gtfs_dir = Path.join(state.data_dir, "gtfs")
     File.mkdir_p!(sources_dir)
     File.mkdir_p!(gtfs_dir)
+    sweep_partials(osm_dir)
 
     with {:ok, sources} <- download_pbfs(state, job_id, entries, sources_dir),
          :ok <- download_gtfs(state, job_id, entries, gtfs_dir),
@@ -252,15 +254,51 @@ defmodule Atlas.Control.RegionApplier do
   defp convert_for_overpass(state, job_id, osm_dir) do
     progress(state, job_id, :converting, %{region: nil, progress: nil})
     bz2 = Path.join(osm_dir, "current.osm.bz2")
+    partial = bz2 <> ".partial"
 
-    # Non-fatal, mirroring the Go sidecar: overpass simply keeps its previous
-    # snapshot if the conversion fails.
+    # Fatal on purpose: a swallowed failure leaves the previous (possibly
+    # weeks-old) current.osm.bz2 in place, and overpass re-imports it with no
+    # indication the refresh never happened.
     case state.osmium_convert.(osm_dir, "current.osm.pbf", "current.osm.bz2.partial") do
-      {:ok, _} -> File.rename(bz2 <> ".partial", bz2)
-      {:error, _code, _output} -> :ok
-    end
+      {:ok, _} ->
+        case File.rename(partial, bz2) do
+          :ok ->
+            :ok
 
-    :ok
+          {:error, reason} ->
+            Logger.error("overpass source conversion reported success but #{partial} is missing")
+            {:error, :converting, {:promote, reason}}
+        end
+
+      {:error, code, output} ->
+        File.rm(partial)
+
+        Logger.error(
+          "overpass source conversion failed (exit #{code}); " <>
+            "#{bz2} left untouched and may be stale: #{output}"
+        )
+
+        {:error, :converting, {code, output}}
+    end
+  end
+
+  # An interrupted merge/convert (restart, OOM, kill) strands a multi-hundred-MB
+  # `.partial`. Sweep before writing new ones so they neither accumulate nor get
+  # mistaken for a completed artifact.
+  defp sweep_partials(osm_dir) do
+    case File.ls(osm_dir) do
+      {:ok, entries} ->
+        for name <- entries, String.ends_with?(name, ".partial") do
+          path = Path.join(osm_dir, name)
+          Logger.info("removing orphaned partial from an interrupted run: #{path}")
+          File.rm(path)
+        end
+
+        :ok
+
+      {:error, _reason} ->
+        :ok
+    end
   end
 
   defp stage_otp(state, job_id, osm_dir, gtfs_dir) do

--- a/app-phoenix/lib/atlas/control/region_applier.ex
+++ b/app-phoenix/lib/atlas/control/region_applier.ex
@@ -7,9 +7,11 @@ defmodule Atlas.Control.RegionApplier do
     2. download GTFS bundles into `gtfs/` (failure is non-fatal)
     3. materialise `osm/current.osm.pbf` — relative symlink for one source,
        `osmium merge` via `.partial` + rename for several
-    4. convert to `osm/current.osm.bz2` for overpass (fatal — a swallowed
-       failure would leave overpass importing a stale snapshot silently)
-    5. stage OTP inputs (`otp/region.osm.pbf` + GTFS zips, drop `graph.obj`)
+    4. stage OTP inputs (`otp/region.osm.pbf` + GTFS zips, drop `graph.obj`)
+    5. convert to `osm/current.osm.bz2` for overpass — last, because it only
+       feeds overpass and can run for hours. Failure is fatal to the apply (a
+       swallowed one would leave overpass importing a stale snapshot silently)
+       but the other services still get restarted onto their fresh data.
     6. `docker compose restart` the enabled ingest services
 
   All paths are container-local under `data_dir` (default `/work/data`) — no
@@ -165,14 +167,24 @@ defmodule Atlas.Control.RegionApplier do
     gtfs_dir = Path.join(state.data_dir, "gtfs")
     File.mkdir_p!(sources_dir)
     File.mkdir_p!(gtfs_dir)
-    sweep_partials(osm_dir)
+    Enum.each([osm_dir, sources_dir, gtfs_dir], &sweep_partials/1)
 
     with {:ok, sources} <- download_pbfs(state, job_id, entries, sources_dir),
          :ok <- download_gtfs(state, job_id, entries, gtfs_dir),
          :ok <- materialize_current(state, job_id, osm_dir, sources_dir, sources),
-         :ok <- convert_for_overpass(state, job_id, osm_dir),
          :ok <- stage_otp(state, job_id, osm_dir, gtfs_dir) do
-      restart_services(state, job_id)
+      # Convert last: it only feeds overpass, and it is the one stage that can
+      # take hours. Everything valhalla and OTP need is already on disk, so a
+      # failed conversion still fails the apply (loudly — see #28) but does not
+      # withhold fresh data from the services that are ready for it.
+      case convert_for_overpass(state, job_id, osm_dir) do
+        :ok ->
+          restart_services(state, job_id, @ingest_services)
+
+        {:error, _phase, _reason} = error ->
+          restart_services(state, job_id, @ingest_services -- ["overpass"])
+          error
+      end
     end
   end
 
@@ -274,7 +286,7 @@ defmodule Atlas.Control.RegionApplier do
         File.rm(partial)
 
         Logger.error(
-          "overpass source conversion failed (exit #{code}); " <>
+          "overpass source conversion failed (#{format_exit(code)}); " <>
             "#{bz2} left untouched and may be stale: #{output}"
         )
 
@@ -331,10 +343,10 @@ defmodule Atlas.Control.RegionApplier do
     end)
   end
 
-  defp restart_services(state, job_id) do
+  defp restart_services(state, job_id, services) do
     progress(state, job_id, :restarting, %{region: nil, progress: nil})
 
-    case state.restart.(@ingest_services) do
+    case state.restart.(services) do
       :ok -> :ok
       {:error, reason} -> {:error, :restarting, reason}
     end
@@ -374,6 +386,11 @@ defmodule Atlas.Control.RegionApplier do
   defp format_reason({url, reason}) when is_binary(url), do: "#{url}: #{format_reason(reason)}"
   defp format_reason({:http_status, status}), do: "HTTP #{status}"
   defp format_reason({code, output}) when is_integer(code), do: "exit #{code}: #{output}"
+  defp format_reason({:stalled, detail}), do: "stalled: #{detail}"
   defp format_reason(%{__exception__: true} = e), do: Exception.message(e)
   defp format_reason(other), do: inspect(other)
+
+  defp format_exit(code) when is_integer(code), do: "exit #{code}"
+  defp format_exit(:stalled), do: "stalled"
+  defp format_exit(other), do: inspect(other)
 end

--- a/app-phoenix/test/atlas/control/osmium_test.exs
+++ b/app-phoenix/test/atlas/control/osmium_test.exs
@@ -2,6 +2,24 @@ defmodule Atlas.Control.OsmiumTest do
   use ExUnit.Case, async: false
   alias Atlas.Control.Osmium
 
+  # True once no process matches `pattern`. pgrep is exec'd directly, NOT via
+  # `sh -c`: a wrapper shell's own argv would contain the pattern, and Linux
+  # procps pgrep matches its ancestors (BSD pgrep excludes them, so that form
+  # passes on macOS and is permanently red on CI). Exit status 1 = no match.
+  defp wait_until_gone(pattern, attempts \\ 100) do
+    case System.cmd("pgrep", ["-f", pattern], stderr_to_stdout: true) do
+      {_, 1} ->
+        true
+
+      _ when attempts > 0 ->
+        Process.sleep(50)
+        wait_until_gone(pattern, attempts - 1)
+
+      _ ->
+        false
+    end
+  end
+
   defp start_osmium(result) do
     test_pid = self()
 
@@ -72,11 +90,11 @@ defmodule Atlas.Control.OsmiumTest do
       on_exit(fn -> File.rm_rf!(tmp) end)
 
       hung_runner = fn _cmd, _args, _opts ->
-        Process.sleep(5_000)
+        Process.sleep(30_000)
         {"never gets here", 0}
       end
 
-      start_supervised!({Osmium, runner: hung_runner, stall_timeout: 150, stall_poll: 30})
+      start_supervised!({Osmium, runner: hung_runner, stall_timeout: 1_000, stall_poll: 200})
 
       assert {:error, :stalled, msg} =
                Osmium.convert_to_osm_bz2(tmp, "current.osm.pbf", "out.partial")
@@ -92,15 +110,20 @@ defmodule Atlas.Control.OsmiumTest do
       out = Path.join(tmp, "out.partial")
 
       growing_runner = fn _cmd, _args, _opts ->
-        Enum.each(1..6, fn n ->
+        Enum.each(1..20, fn n ->
           File.write!(out, String.duplicate("x", n * 1000))
-          Process.sleep(50)
+          Process.sleep(100)
         end)
 
         {"done", 0}
       end
 
-      start_supervised!({Osmium, runner: growing_runner, stall_timeout: 150, stall_poll: 30})
+      # The run (~2s) deliberately outlives the 1.5s no-growth tolerance, so a
+      # pass proves growth RESETS the stall counter rather than proving the
+      # convert simply finished first. The write interval (100ms) sits far
+      # under the tolerance, so it survives a heavily loaded runner: growth has
+      # to go unobserved for 1.5s straight before anything is killed.
+      start_supervised!({Osmium, runner: growing_runner, stall_timeout: 1_500, stall_poll: 200})
 
       assert {:ok, "done"} = Osmium.convert_to_osm_bz2(tmp, "current.osm.pbf", "out.partial")
     end
@@ -117,7 +140,16 @@ defmodule Atlas.Control.OsmiumTest do
       # can see it. A trailing comment would not — `exec` replaces the shell and
       # the comment never reaches argv, which makes the pgrep assertion pass
       # whether or not the child was actually killed.
-      marker = 4000 + rem(System.unique_integer([:positive]), 900)
+      #
+      # It has to be unique across RUNS, not just within one: should this test
+      # ever leak a child, that process sleeps for an hour and a narrow marker
+      # range would make every later run collide with the orphan and fail. The
+      # uniqueness rides in the fraction — concatenating pid and counter into
+      # the whole-seconds part overflows what `sleep` accepts.
+      marker = "3600.#{List.to_string(:os.getpid())}#{System.unique_integer([:positive])}"
+
+      # Belt and braces: never leak a multi-hour sleep, even if we fail early.
+      on_exit(fn -> System.cmd("pkill", ["-f", "sleep #{marker}"], stderr_to_stdout: true) end)
 
       # The real port-spawning runner, just pointed at `sleep` so the test does
       # not need osmium installed.
@@ -125,27 +157,34 @@ defmodule Atlas.Control.OsmiumTest do
         Osmium.spawn_and_collect("sleep", ["#{marker}"], opts)
       end
 
-      start_supervised!({Osmium, runner: port_runner, stall_timeout: 150, stall_poll: 30})
+      # Generous on purpose. The watchdog must not reach its deadline before the
+      # Task has even been scheduled and the port opened — otherwise there is no
+      # pid to kill yet and the test fails for a reason that says nothing about
+      # the behaviour under test. A loaded CI runner makes tight values a
+      # coin flip.
+      start_supervised!({Osmium, runner: port_runner, stall_timeout: 1_000, stall_poll: 200})
 
       assert {:error, :stalled, _} =
                Osmium.convert_to_osm_bz2(tmp, "current.osm.pbf", "out.partial")
 
-      Process.sleep(300)
-
-      # pgrep directly, NOT through `sh -c`: the wrapper shell's own argv would
-      # contain the pattern, and Linux procps pgrep matches its own ancestors
-      # (BSD pgrep excludes them, which is why that form passes on macOS and is
-      # permanently red on CI). Exit status 1 means nothing matched.
-      {_, status} = System.cmd("pgrep", ["-f", "sleep #{marker}"], stderr_to_stdout: true)
-
-      assert status == 1,
+      # Poll rather than sleeping a fixed span: reaping a SIGKILLed process is
+      # not instantaneous, and on a loaded runner a fixed wait is a coin flip.
+      assert wait_until_gone("sleep #{marker}"),
              "the child must be dead once we report it killed — otherwise it keeps " <>
                "writing to the data dir while the freed GenServer admits a second run"
     end
 
     test "spawn_and_collect reports the OS pid and returns output with the exit status" do
+      # The child has to outlive the Port.info/2 call: a process that exits
+      # immediately can close the port first, and Port.info then returns nil so
+      # no pid is ever reported. Harmless in production — a stalled osmium has
+      # been running for half an hour by the time the watchdog asks — but on a
+      # loaded CI runner `echo` alone is fast enough to lose the race.
       assert {"hello\n", 0} =
-               Osmium.spawn_and_collect("echo", ["hello"], cd: File.cwd!(), report_to: self())
+               Osmium.spawn_and_collect("sh", ["-c", "sleep 0.2; echo hello"],
+                 cd: File.cwd!(),
+                 report_to: self()
+               )
 
       assert_received {:osmium_os_pid, os_pid} when is_integer(os_pid)
 

--- a/app-phoenix/test/atlas/control/osmium_test.exs
+++ b/app-phoenix/test/atlas/control/osmium_test.exs
@@ -105,6 +105,45 @@ defmodule Atlas.Control.OsmiumTest do
       assert {:ok, "done"} = Osmium.convert_to_osm_bz2(tmp, "current.osm.pbf", "out.partial")
     end
 
+    test "the stall watchdog kills the real OS process, not just the Elixir task" do
+      # Task.shutdown/2 tears down the wrapper only; the port's child survives.
+      # If osmium outlives the "killed" reply it keeps writing to the data dir
+      # while the freed GenServer lets the next apply start a second one.
+      tmp = Path.join(System.tmp_dir!(), "osmium-kill-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf!(tmp) end)
+
+      marker = "atlas-stall-#{System.unique_integer([:positive])}"
+
+      # The real port-spawning runner, just pointed at `sleep` so the test does
+      # not need osmium installed.
+      port_runner = fn _cmd, _args, opts ->
+        Osmium.spawn_and_collect("sh", ["-c", "exec sleep 30 # #{marker}"], opts)
+      end
+
+      start_supervised!({Osmium, runner: port_runner, stall_timeout: 150, stall_poll: 30})
+
+      assert {:error, :stalled, _} =
+               Osmium.convert_to_osm_bz2(tmp, "current.osm.pbf", "out.partial")
+
+      Process.sleep(300)
+
+      {out, _} = System.cmd("sh", ["-c", "pgrep -f '#{marker}' | wc -l"])
+
+      assert String.trim(out) == "0",
+             "the child must be dead once we report it killed — otherwise it keeps " <>
+               "writing to the data dir while the freed GenServer admits a second run"
+    end
+
+    test "spawn_and_collect reports the OS pid and returns output with the exit status" do
+      assert {"hello\n", 0} =
+               Osmium.spawn_and_collect("echo", ["hello"], cd: File.cwd!(), report_to: self())
+
+      assert_received {:osmium_os_pid, os_pid} when is_integer(os_pid)
+
+      assert {"", 3} = Osmium.spawn_and_collect("sh", ["-c", "exit 3"], cd: File.cwd!())
+    end
+
     test "an explicit timeout override is honoured" do
       Application.put_env(:atlas, :osmium_timeout, 20)
       on_exit(fn -> Application.delete_env(:atlas, :osmium_timeout) end)

--- a/app-phoenix/test/atlas/control/osmium_test.exs
+++ b/app-phoenix/test/atlas/control/osmium_test.exs
@@ -43,4 +43,42 @@ defmodule Atlas.Control.OsmiumTest do
     assert {:error, 1, "Open failed for 'a.osm.pbf'"} =
              Osmium.merge("/work/data/osm/sources", ["a.osm.pbf"], "out.osm.pbf")
   end
+
+  describe "call timeout" do
+    test "defaults to :infinity so a slow convert is never killed by wall clock" do
+      assert Osmium.call_timeout() == :infinity
+    end
+
+    test "a convert far longer than the old 30-minute ceiling still succeeds" do
+      # bzip2 compression of a country-scale PBF runs 45-50 min; the previous
+      # hard-coded :timer.minutes(30) killed it mid-write.
+      slow_runner = fn _cmd, _args, _opts ->
+        Process.sleep(120)
+        {"done", 0}
+      end
+
+      start_supervised!({Osmium, runner: slow_runner})
+
+      assert {:ok, "done"} =
+               Osmium.convert_to_osm_bz2("/work/data/osm", "current.osm.pbf", "out.partial")
+    end
+
+    test "an explicit timeout override is honoured" do
+      Application.put_env(:atlas, :osmium_timeout, 20)
+      on_exit(fn -> Application.delete_env(:atlas, :osmium_timeout) end)
+
+      assert Osmium.call_timeout() == 20
+
+      blocking_runner = fn _cmd, _args, _opts ->
+        Process.sleep(500)
+        {"done", 0}
+      end
+
+      start_supervised!({Osmium, runner: blocking_runner})
+
+      assert catch_exit(
+               Osmium.convert_to_osm_bz2("/work/data/osm", "current.osm.pbf", "out.partial")
+             )
+    end
+  end
 end

--- a/app-phoenix/test/atlas/control/osmium_test.exs
+++ b/app-phoenix/test/atlas/control/osmium_test.exs
@@ -63,6 +63,48 @@ defmodule Atlas.Control.OsmiumTest do
                Osmium.convert_to_osm_bz2("/work/data/osm", "current.osm.pbf", "out.partial")
     end
 
+    test "a stalled convert is killed even though the call timeout is :infinity" do
+      # :infinity is right for a SLOW convert (bzip2 on a planet extract runs
+      # for hours). A HUNG one is different: without a stall check the GenServer
+      # is wedged forever and every later apply gets {:error, :busy}.
+      tmp = Path.join(System.tmp_dir!(), "osmium-stall-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf!(tmp) end)
+
+      hung_runner = fn _cmd, _args, _opts ->
+        Process.sleep(5_000)
+        {"never gets here", 0}
+      end
+
+      start_supervised!({Osmium, runner: hung_runner, stall_timeout: 150, stall_poll: 30})
+
+      assert {:error, :stalled, msg} =
+               Osmium.convert_to_osm_bz2(tmp, "current.osm.pbf", "out.partial")
+
+      assert msg =~ "no progress"
+    end
+
+    test "a slow but progressing convert is not killed by the stall watchdog" do
+      tmp = Path.join(System.tmp_dir!(), "osmium-slow-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf!(tmp) end)
+
+      out = Path.join(tmp, "out.partial")
+
+      growing_runner = fn _cmd, _args, _opts ->
+        Enum.each(1..6, fn n ->
+          File.write!(out, String.duplicate("x", n * 1000))
+          Process.sleep(50)
+        end)
+
+        {"done", 0}
+      end
+
+      start_supervised!({Osmium, runner: growing_runner, stall_timeout: 150, stall_poll: 30})
+
+      assert {:ok, "done"} = Osmium.convert_to_osm_bz2(tmp, "current.osm.pbf", "out.partial")
+    end
+
     test "an explicit timeout override is honoured" do
       Application.put_env(:atlas, :osmium_timeout, 20)
       on_exit(fn -> Application.delete_env(:atlas, :osmium_timeout) end)

--- a/app-phoenix/test/atlas/control/osmium_test.exs
+++ b/app-phoenix/test/atlas/control/osmium_test.exs
@@ -132,9 +132,13 @@ defmodule Atlas.Control.OsmiumTest do
 
       Process.sleep(300)
 
-      {out, _} = System.cmd("sh", ["-c", "pgrep -f 'sleep #{marker}' | wc -l"])
+      # pgrep directly, NOT through `sh -c`: the wrapper shell's own argv would
+      # contain the pattern, and Linux procps pgrep matches its own ancestors
+      # (BSD pgrep excludes them, which is why that form passes on macOS and is
+      # permanently red on CI). Exit status 1 means nothing matched.
+      {_, status} = System.cmd("pgrep", ["-f", "sleep #{marker}"], stderr_to_stdout: true)
 
-      assert String.trim(out) == "0",
+      assert status == 1,
              "the child must be dead once we report it killed — otherwise it keeps " <>
                "writing to the data dir while the freed GenServer admits a second run"
     end

--- a/app-phoenix/test/atlas/control/osmium_test.exs
+++ b/app-phoenix/test/atlas/control/osmium_test.exs
@@ -113,12 +113,16 @@ defmodule Atlas.Control.OsmiumTest do
       File.mkdir_p!(tmp)
       on_exit(fn -> File.rm_rf!(tmp) end)
 
-      marker = "atlas-stall-#{System.unique_integer([:positive])}"
+      # The duration IS the marker: it lands in the child's own argv, so pgrep
+      # can see it. A trailing comment would not — `exec` replaces the shell and
+      # the comment never reaches argv, which makes the pgrep assertion pass
+      # whether or not the child was actually killed.
+      marker = 4000 + rem(System.unique_integer([:positive]), 900)
 
       # The real port-spawning runner, just pointed at `sleep` so the test does
       # not need osmium installed.
       port_runner = fn _cmd, _args, opts ->
-        Osmium.spawn_and_collect("sh", ["-c", "exec sleep 30 # #{marker}"], opts)
+        Osmium.spawn_and_collect("sleep", ["#{marker}"], opts)
       end
 
       start_supervised!({Osmium, runner: port_runner, stall_timeout: 150, stall_poll: 30})
@@ -128,7 +132,7 @@ defmodule Atlas.Control.OsmiumTest do
 
       Process.sleep(300)
 
-      {out, _} = System.cmd("sh", ["-c", "pgrep -f '#{marker}' | wc -l"])
+      {out, _} = System.cmd("sh", ["-c", "pgrep -f 'sleep #{marker}' | wc -l"])
 
       assert String.trim(out) == "0",
              "the child must be dead once we report it killed — otherwise it keeps " <>

--- a/app-phoenix/test/atlas/control/region_applier_test.exs
+++ b/app-phoenix/test/atlas/control/region_applier_test.exs
@@ -103,7 +103,12 @@ defmodule Atlas.Control.RegionApplierTest do
       assert_receive {:apply_error, %{job_id: ^job_id, phase: :converting, reason: reason}}, 2_000
       assert reason =~ "osmium: killed"
 
-      refute_received {:restart, _}
+      assert File.read!(stale) == "seven-weeks-old",
+             "the stale bz2 stays on disk, but the apply reports failure rather than " <>
+               "letting overpass silently re-import it as if it were fresh"
+
+      assert_received {:restart, services}
+      refute "overpass" in services
     end
 
     test "a successful convert still promotes .partial to the real bz2", %{tmp: tmp} do
@@ -117,6 +122,25 @@ defmodule Atlas.Control.RegionApplierTest do
 
       assert File.read!(Path.join(tmp, "osm/current.osm.bz2")) == "bz2"
       refute File.exists?(Path.join(tmp, "osm/current.osm.bz2.partial"))
+    end
+
+    test "a failed convert still stages OTP and restarts the other ingest services",
+         %{tmp: tmp} do
+      start_applier(tmp,
+        osmium_convert: fn _dir, _in_path, _out -> {:error, 1, "osmium: killed"} end
+      )
+
+      assert {:ok, job_id} = RegionApplier.start(["berlin"])
+      assert_receive {:apply_error, %{job_id: ^job_id, phase: :converting}}, 2_000
+
+      assert File.exists?(Path.join(tmp, "otp/region.osm.pbf")),
+             "a broken overpass source must not withhold the fresh PBF from OTP"
+
+      assert_received {:restart, services},
+                      "valhalla/otp got new data and must still be restarted"
+
+      refute "overpass" in services,
+             "overpass must NOT be restarted onto a source that failed to convert"
     end
 
     test "orphaned .partial files from a previous run are swept at apply start", %{tmp: tmp} do
@@ -133,6 +157,27 @@ defmodule Atlas.Control.RegionApplierTest do
       refute File.exists?(Path.join(osm, "current.osm.pbf.partial"))
 
       assert File.read!(Path.join(osm, "current.osm.bz2")) == "bz2"
+    end
+
+    test "the sweep also clears interrupted downloads under sources/ and gtfs/", %{tmp: tmp} do
+      osm = Path.join(tmp, "osm")
+      sources = Path.join(osm, "sources")
+      gtfs = Path.join(tmp, "gtfs")
+      File.mkdir_p!(sources)
+      File.mkdir_p!(gtfs)
+
+      # A killed download leaves a multi-hundred-MB .partial; the downloader
+      # truncates on retry rather than resuming, so it is pure garbage.
+      File.write!(Path.join(sources, "berlin-latest.osm.pbf.partial"), "interrupted")
+      File.write!(Path.join(gtfs, "vbb.gtfs.zip.partial"), "interrupted")
+
+      start_applier(tmp)
+
+      assert {:ok, job_id} = RegionApplier.start(["berlin"])
+      assert_receive {:apply_done, %{job_id: ^job_id}}, 2_000
+
+      refute File.exists?(Path.join(sources, "berlin-latest.osm.pbf.partial"))
+      refute File.exists?(Path.join(gtfs, "vbb.gtfs.zip.partial"))
     end
   end
 

--- a/app-phoenix/test/atlas/control/region_applier_test.exs
+++ b/app-phoenix/test/atlas/control/region_applier_test.exs
@@ -73,6 +73,69 @@ defmodule Atlas.Control.RegionApplierTest do
     {:ok, tmp: tmp}
   end
 
+  describe "overpass source conversion" do
+    test "a failed convert removes the orphaned .partial", %{tmp: tmp} do
+      start_applier(tmp,
+        osmium_convert: fn dir, _in_path, out ->
+          File.write!(Path.expand(out, dir), "half-written")
+          {:error, 1, "osmium: killed"}
+        end
+      )
+
+      assert {:ok, job_id} = RegionApplier.start(["berlin"])
+      assert_receive {:apply_error, %{job_id: ^job_id}}, 2_000
+
+      refute File.exists?(Path.join(tmp, "osm/current.osm.bz2.partial")),
+             "orphaned .partial must be cleaned up, not left to accumulate"
+    end
+
+    test "a failed convert fails the apply loudly instead of keeping stale data", %{tmp: tmp} do
+      File.mkdir_p!(Path.join(tmp, "osm"))
+      stale = Path.join(tmp, "osm/current.osm.bz2")
+      File.write!(stale, "seven-weeks-old")
+
+      start_applier(tmp,
+        osmium_convert: fn _dir, _in_path, _out -> {:error, 1, "osmium: killed"} end
+      )
+
+      assert {:ok, job_id} = RegionApplier.start(["berlin"])
+
+      assert_receive {:apply_error, %{job_id: ^job_id, phase: :converting, reason: reason}}, 2_000
+      assert reason =~ "osmium: killed"
+
+      refute_received {:restart, _}
+    end
+
+    test "a successful convert still promotes .partial to the real bz2", %{tmp: tmp} do
+      File.mkdir_p!(Path.join(tmp, "osm"))
+      File.write!(Path.join(tmp, "osm/current.osm.bz2"), "seven-weeks-old")
+
+      start_applier(tmp)
+
+      assert {:ok, job_id} = RegionApplier.start(["berlin"])
+      assert_receive {:apply_done, %{job_id: ^job_id}}, 2_000
+
+      assert File.read!(Path.join(tmp, "osm/current.osm.bz2")) == "bz2"
+      refute File.exists?(Path.join(tmp, "osm/current.osm.bz2.partial"))
+    end
+
+    test "orphaned .partial files from a previous run are swept at apply start", %{tmp: tmp} do
+      osm = Path.join(tmp, "osm")
+      File.mkdir_p!(osm)
+      File.write!(Path.join(osm, "current.osm.bz2.partial"), "interrupted")
+      File.write!(Path.join(osm, "current.osm.pbf.partial"), "interrupted")
+
+      start_applier(tmp)
+
+      assert {:ok, job_id} = RegionApplier.start(["berlin"])
+      assert_receive {:apply_done, %{job_id: ^job_id}}, 2_000
+
+      refute File.exists?(Path.join(osm, "current.osm.pbf.partial"))
+
+      assert File.read!(Path.join(osm, "current.osm.bz2")) == "bz2"
+    end
+  end
+
   test "single region: download, symlink, convert, stage otp, restart", %{tmp: tmp} do
     File.mkdir_p!(Path.join(tmp, "otp"))
     File.write!(Path.join(tmp, "otp/graph.obj"), "stale")

--- a/app-phoenix/test/atlas_web/live/admin/apply_live_test.exs
+++ b/app-phoenix/test/atlas_web/live/admin/apply_live_test.exs
@@ -66,8 +66,8 @@ defmodule AtlasWeb.Admin.ApplyLiveTest do
     start_supervised!(
       {RegionApplier,
        downloader: downloader,
-       osmium_convert: fn _dir, _in, out ->
-         File.write!(Path.expand(out, tmp), "bz2")
+       osmium_convert: fn dir, _in, out ->
+         File.write!(Path.expand(out, dir), "bz2")
          {:ok, "ok"}
        end,
        restart: fn _names -> :ok end,
@@ -152,8 +152,8 @@ defmodule AtlasWeb.Admin.ApplyLiveTest do
     start_supervised!(
       {RegionApplier,
        downloader: downloader,
-       osmium_convert: fn _dir, _in, out ->
-         File.write!(Path.expand(out, tmp), "bz2")
+       osmium_convert: fn dir, _in, out ->
+         File.write!(Path.expand(out, dir), "bz2")
          {:ok, "ok"}
        end,
        restart: fn _names -> :ok end,


### PR DESCRIPTION
Fixes #34 and #28 — one causal chain, so fixed together.

## Problem

`Atlas.Control.Osmium` ran every invocation behind a hard-coded `:timer.minutes(30)` `GenServer.call` timeout. bzip2 compression is effectively single-threaded, so a country-scale `osmium cat -f osm.bz2` takes 45–50 min — the call timed out at exactly 30:00 and **region apply could never complete** for regions that size (#34).

The kill also stranded `current.osm.bz2.partial`, and `convert_for_overpass` swallowed the failure and returned `:ok`. The previous — possibly weeks-old — `current.osm.bz2` stayed in place and overpass re-imported it, with nothing indicating the refresh had failed (#28). The reporter's instance served `timestamp_osm_base` 7 weeks behind.

## Change

**#34** — the call timeout is now `:infinity`, overridable via `config :atlas, :osmium_timeout`. That GenServer exists to serialize access to the data dir; a wall-clock deadline was never what it was for.

**#28** — in `RegionApplier`:
- orphaned `*.partial` files from an interrupted run are swept at apply start;
- a failed convert removes its `.partial` and logs at `:error`;
- a failed convert is now **fatal to the apply** rather than silently non-fatal;
- a convert that reports success but leaves no `.partial` is also surfaced instead of being ignored.

## Behaviour change worth a look

Conversion failure was explicitly non-fatal ("mirroring the Go sidecar"). It is now fatal, which is what both issues ask for — but it also means a failed Overpass conversion skips the valhalla/otp restart at the end of the pipeline. The trade is a loud stop versus silently serving weeks-old POI data; #28 argues for the former. Say the word if you'd rather it warn and continue.

## Tests

```
401 tests, 0 failures
```

New: `.partial` cleanup on failure, loud failure instead of stale reuse, successful-convert promotion (regression guard), and the startup sweep. Osmium gains coverage for the default `:infinity`, an override, and a convert outlasting the old ceiling.

Also fixes a latent bug in `apply_live_test.exs`: its `osmium_convert` stub wrote to `tmp` instead of the `dir` it was handed, so the rename silently failed — exactly the class of silence this PR removes. The stub now honours its argument.