### PR TITLE
Make public scheme, port, force_ssl and check_origin configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,23 +26,38 @@
 #   will tell you when this is the case).
 # DOCKER_GID=999
 
-# Public URL. Defaults assume Atlas sits behind a TLS-terminating proxy:
-# https on 443, with plain HTTP redirected up to HTTPS.
+# Public URL — the scheme/host/port CLIENTS use to reach Atlas.
 #
-# For a headless LAN host reachable over plain HTTP on a non-standard port,
-# set the scheme and port — FORCE_SSL then defaults to false, so there is no
-# redirect to https, and LiveView's origin check validates against the real
-# http://HOST:PORT the browser actually used:
+# Out of the box `docker compose up` publishes Caddy on plain HTTP at :8484 and
+# PHX_HOST stays `localhost`, which works with no settings here at all (the
+# HTTPS redirect always skips localhost/127.0.0.1).
 #
-#   PHX_HOST=192.168.5.99
-#   PHX_SCHEME=http
-#   PHX_PORT=8484
+# You only need this block once you reach Atlas by a real hostname or IP:
 #
-# FORCE_SSL: override the redirect explicitly (default: true, or false when
-#   PHX_SCHEME=http).
-# PHX_CHECK_ORIGIN: `false`, or a comma-separated allow list, when the
-#   defaults above don't describe every origin clients arrive from.
-# PHX_HOST=localhost
+#   LAN / headless box over plain HTTP — the shipped topology, no TLS anywhere.
+#   PHX_SCHEME=http also turns the HTTPS redirect off, and LiveView's origin
+#   check then validates against the real http://HOST:PORT the browser used:
+#       PHX_HOST=192.168.5.99
+#       PHX_SCHEME=http
+#       PHX_PORT=8484
+#
+#   Behind a TLS-terminating proxy (Traefik, nginx, Dokploy) — the defaults
+#   already describe this, so only PHX_HOST is required:
+#       PHX_HOST=atlas.example.com
+#
+# ⚠️ PHX_PORT is the port clients connect to, NOT the port Atlas publishes.
+#    It must MATCH the published port — change `ports:` in compose.yml (or your
+#    proxy) to move that; PHX_PORT only tells Atlas how to describe itself in
+#    redirects, generated URLs and LiveView origin checks.
+#
+# PHX_SCHEME: `http` or `https` (default: https). A misspelling is rejected at
+#   boot rather than silently falling back to https.
+# FORCE_SSL: override the HTTPS redirect explicitly (default: true, or false
+#   when PHX_SCHEME=http).
+# PHX_CHECK_ORIGIN: `false`, or a comma-separated allow list of FULL origins
+#   (scheme included), when the values above don't describe every origin
+#   clients arrive from.
+# PHX_HOST=192.168.5.99
 # PHX_SCHEME=http
 # PHX_PORT=8484
 # FORCE_SSL=false

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,28 @@
 #   will tell you when this is the case).
 # DOCKER_GID=999
 
+# Public URL. Defaults assume Atlas sits behind a TLS-terminating proxy:
+# https on 443, with plain HTTP redirected up to HTTPS.
+#
+# For a headless LAN host reachable over plain HTTP on a non-standard port,
+# set the scheme and port — FORCE_SSL then defaults to false, so there is no
+# redirect to https, and LiveView's origin check validates against the real
+# http://HOST:PORT the browser actually used:
+#
+#   PHX_HOST=192.168.5.99
+#   PHX_SCHEME=http
+#   PHX_PORT=8484
+#
+# FORCE_SSL: override the redirect explicitly (default: true, or false when
+#   PHX_SCHEME=http).
+# PHX_CHECK_ORIGIN: `false`, or a comma-separated allow list, when the
+#   defaults above don't describe every origin clients arrive from.
+# PHX_HOST=localhost
+# PHX_SCHEME=http
+# PHX_PORT=8484
+# FORCE_SSL=false
+# PHX_CHECK_ORIGIN=http://192.168.5.99:8484,https://atlas.example.com
+
 # Region selection (ISO-2 country code; see Geofabrik for valid extracts)
 COUNTRY_CODE=de
 PBF_URL=https://download.geofabrik.de/europe/germany-latest.osm.pbf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Headless LAN deployments work over plain HTTP on a non-standard port: `PHX_SCHEME`, `PHX_PORT`, `FORCE_SSL` and `PHX_CHECK_ORIGIN` are now configurable, and `PHX_SCHEME=http` turns the HTTPS redirect off by default (#19)
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/app-phoenix/config/prod.exs
+++ b/app-phoenix/config/prod.exs
@@ -8,7 +8,11 @@ config :atlas, AtlasWeb.Endpoint,
     rewrite_on: [:x_forwarded_proto],
     exclude: [
       # paths: ["/health"],
-      hosts: ["localhost", "127.0.0.1"]
+      hosts: ["localhost", "127.0.0.1"],
+      # `:force_ssl` is compile-time, so FORCE_SSL=false (or PHX_SCHEME=http)
+      # cannot unplug Plug.SSL. This callback runs per request and applies the
+      # runtime setting resolved in config/runtime.exs.
+      conn: {AtlasWeb.EndpointConfig, :skip_https_redirect?, []}
     ]
   ]
 

--- a/app-phoenix/config/runtime.exs
+++ b/app-phoenix/config/runtime.exs
@@ -66,9 +66,13 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
-  host = System.get_env("PHX_HOST") || "example.com"
+  env = System.get_env()
 
   config :atlas, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
+
+  # Read back by AtlasWeb.EndpointConfig.skip_https_redirect?/1, the runtime
+  # gate on the compile-time Plug.SSL. See config/prod.exs.
+  config :atlas, :force_ssl, AtlasWeb.EndpointConfig.force_ssl?(env)
 
   # Docker bridge networks are IPv4, so bind 0.0.0.0 by default — binding the
   # IPv6 wildcard (::) refuses IPv4 connections on hosts without dual-stack.
@@ -79,7 +83,8 @@ if config_env() == :prod do
       else: {0, 0, 0, 0}
 
   config :atlas, AtlasWeb.Endpoint,
-    url: [host: host, port: 443, scheme: "https"],
+    url: AtlasWeb.EndpointConfig.url(env),
+    check_origin: AtlasWeb.EndpointConfig.check_origin(env),
     http: [ip: bind_ip],
     secret_key_base: secret_key_base
 

--- a/app-phoenix/lib/atlas_web/endpoint_config.ex
+++ b/app-phoenix/lib/atlas_web/endpoint_config.ex
@@ -25,11 +25,29 @@ defmodule AtlasWeb.EndpointConfig do
   @doc "Public hostname clients reach Atlas on."
   def host(env), do: presence(env["PHX_HOST"]) || @default_host
 
-  @doc "Public scheme — `https` unless explicitly set to `http`."
+  @doc """
+  Public scheme — `https` unless explicitly set to `http`.
+
+  A misspelling raises rather than falling back to `https`: silently keeping
+  the redirect on is exactly the failure the operator was trying to escape.
+  """
   def scheme(env) do
     case presence(env["PHX_SCHEME"]) do
-      "http" -> "http"
-      _ -> @default_scheme
+      nil ->
+        @default_scheme
+
+      value ->
+        case String.downcase(value) do
+          "http" ->
+            "http"
+
+          "https" ->
+            "https"
+
+          other ->
+            raise ArgumentError,
+                  "PHX_SCHEME must be \"http\" or \"https\", got: #{inspect(other)}"
+        end
     end
   end
 
@@ -39,7 +57,18 @@ defmodule AtlasWeb.EndpointConfig do
 
     case presence(env["PHX_PORT"]) do
       nil -> if scheme == "http", do: 80, else: 443
-      value -> String.to_integer(value)
+      value -> parse_port(value)
+    end
+  end
+
+  defp parse_port(value) do
+    case Integer.parse(value) do
+      {port, ""} when port in 1..65_535 ->
+        port
+
+      _ ->
+        raise ArgumentError,
+              "PHX_PORT must be an integer between 1 and 65535, got: #{inspect(value)}"
     end
   end
 

--- a/app-phoenix/lib/atlas_web/endpoint_config.ex
+++ b/app-phoenix/lib/atlas_web/endpoint_config.ex
@@ -1,0 +1,97 @@
+defmodule AtlasWeb.EndpointConfig do
+  @moduledoc """
+  Resolves the externally-visible endpoint settings from the environment.
+
+  Atlas is deployed three ways, and they disagree about scheme and port:
+
+    * behind a TLS-terminating proxy — `https` on 443 (the default)
+    * directly on a LAN host — `http` on a non-standard port such as 8484
+    * on localhost for a quick look
+
+  Pure functions over an env map so each combination is testable without
+  booting an endpoint. `config/runtime.exs` feeds them `System.get_env/0`.
+  """
+
+  @default_host "example.com"
+  @default_scheme "https"
+  @falsey ~w(false 0 no off)
+
+  @doc "Endpoint `:url` config — the host/port/scheme Atlas advertises."
+  def url(env) do
+    scheme = scheme(env)
+    [host: host(env), port: port(env, scheme), scheme: scheme]
+  end
+
+  @doc "Public hostname clients reach Atlas on."
+  def host(env), do: presence(env["PHX_HOST"]) || @default_host
+
+  @doc "Public scheme — `https` unless explicitly set to `http`."
+  def scheme(env) do
+    case presence(env["PHX_SCHEME"]) do
+      "http" -> "http"
+      _ -> @default_scheme
+    end
+  end
+
+  @doc "Public port. Defaults to the scheme's standard port."
+  def port(env, scheme \\ nil) do
+    scheme = scheme || scheme(env)
+
+    case presence(env["PHX_PORT"]) do
+      nil -> if scheme == "http", do: 80, else: 443
+      value -> String.to_integer(value)
+    end
+  end
+
+  @doc """
+  Whether to redirect plain HTTP to HTTPS.
+
+  Defaults to `true`, but follows `PHX_SCHEME=http` down to `false` — asking
+  to be served over http and then being redirected to https is never what the
+  operator meant. An explicit `FORCE_SSL` always wins.
+  """
+  def force_ssl?(env) do
+    case presence(env["FORCE_SSL"]) do
+      nil -> scheme(env) != "http"
+      value -> String.downcase(value) not in @falsey
+    end
+  end
+
+  @doc """
+  LiveView origin policy: `true` (validate against `url/1`), `false`, or an
+  explicit allow list from a comma-separated `PHX_CHECK_ORIGIN`.
+  """
+  def check_origin(env) do
+    case presence(env["PHX_CHECK_ORIGIN"]) do
+      nil ->
+        true
+
+      value ->
+        if String.downcase(value) in @falsey do
+          false
+        else
+          value
+          |> String.split(",")
+          |> Enum.map(&String.trim/1)
+          |> Enum.reject(&(&1 == ""))
+        end
+    end
+  end
+
+  @doc """
+  Runtime gate for `Plug.SSL`, wired through `force_ssl: [exclude: [conn: …]]`.
+
+  Phoenix reads `:force_ssl` with `Application.compile_env/2`, so the plug is
+  baked into the endpoint at build time and `FORCE_SSL=false` cannot remove
+  it. `:exclude`'s `conn:` callback *is* evaluated per request, so the runtime
+  setting is applied here instead.
+  """
+  def skip_https_redirect?(_conn), do: not Application.get_env(:atlas, :force_ssl, true)
+
+  defp presence(nil), do: nil
+  defp presence(""), do: nil
+  defp presence(value) when is_binary(value), do: String.trim(value) |> nil_if_empty()
+
+  defp nil_if_empty(""), do: nil
+  defp nil_if_empty(value), do: value
+end

--- a/app-phoenix/test/atlas_web/endpoint_config_test.exs
+++ b/app-phoenix/test/atlas_web/endpoint_config_test.exs
@@ -1,5 +1,6 @@
 defmodule AtlasWeb.EndpointConfigTest do
-  use ExUnit.Case, async: true
+  # Not async: the Plug.SSL cases flip the global :force_ssl application env.
+  use ExUnit.Case, async: false
 
   import Plug.Test, only: [conn: 2]
 
@@ -27,6 +28,36 @@ defmodule AtlasWeb.EndpointConfigTest do
 
       assert EndpointConfig.url(env) ==
                [host: "192.168.5.99", port: 8484, scheme: "http"]
+    end
+  end
+
+  describe "operator typos" do
+    test "PHX_SCHEME is matched case-insensitively" do
+      assert EndpointConfig.scheme(%{"PHX_SCHEME" => "HTTP"}) == "http"
+      assert EndpointConfig.scheme(%{"PHX_SCHEME" => "Http"}) == "http"
+      refute EndpointConfig.force_ssl?(%{"PHX_SCHEME" => "HTTP"})
+    end
+
+    test "an unrecognised PHX_SCHEME is rejected loudly, not silently coerced to https" do
+      assert_raise ArgumentError, ~r/PHX_SCHEME/, fn ->
+        EndpointConfig.scheme(%{"PHX_SCHEME" => "htp"})
+      end
+    end
+
+    test "a malformed PHX_PORT names the variable instead of raising from String.to_integer" do
+      err =
+        assert_raise ArgumentError, fn ->
+          EndpointConfig.port(%{"PHX_PORT" => "not-a-number"})
+        end
+
+      assert Exception.message(err) =~ "PHX_PORT"
+      assert Exception.message(err) =~ "not-a-number"
+    end
+
+    test "an out-of-range PHX_PORT is rejected" do
+      assert_raise ArgumentError, ~r/PHX_PORT/, fn ->
+        EndpointConfig.port(%{"PHX_PORT" => "70000"})
+      end
     end
   end
 

--- a/app-phoenix/test/atlas_web/endpoint_config_test.exs
+++ b/app-phoenix/test/atlas_web/endpoint_config_test.exs
@@ -1,0 +1,133 @@
+defmodule AtlasWeb.EndpointConfigTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Test, only: [conn: 2]
+
+  alias AtlasWeb.EndpointConfig
+
+  describe "url/1 defaults" do
+    test "keeps the public HTTPS defaults when nothing is set" do
+      assert EndpointConfig.url(%{"PHX_HOST" => "atlas.example.com"}) ==
+               [host: "atlas.example.com", port: 443, scheme: "https"]
+    end
+
+    test "falls back to example.com when PHX_HOST is unset" do
+      assert EndpointConfig.url(%{})[:host] == "example.com"
+    end
+  end
+
+  describe "url/1 with PHX_SCHEME=http" do
+    test "defaults the port to 80" do
+      assert EndpointConfig.url(%{"PHX_HOST" => "192.168.5.99", "PHX_SCHEME" => "http"}) ==
+               [host: "192.168.5.99", port: 80, scheme: "http"]
+    end
+
+    test "honours an explicit non-standard port" do
+      env = %{"PHX_HOST" => "192.168.5.99", "PHX_SCHEME" => "http", "PHX_PORT" => "8484"}
+
+      assert EndpointConfig.url(env) ==
+               [host: "192.168.5.99", port: 8484, scheme: "http"]
+    end
+  end
+
+  describe "force_ssl?/1" do
+    test "defaults to true so public deployments stay protected" do
+      assert EndpointConfig.force_ssl?(%{})
+    end
+
+    test "defaults to false when the public scheme is plain http" do
+      refute EndpointConfig.force_ssl?(%{"PHX_SCHEME" => "http"})
+    end
+
+    test "an explicit FORCE_SSL=false disables the redirect on https" do
+      refute EndpointConfig.force_ssl?(%{"FORCE_SSL" => "false"})
+      refute EndpointConfig.force_ssl?(%{"FORCE_SSL" => "0"})
+    end
+
+    test "an explicit FORCE_SSL=true wins over an http scheme" do
+      assert EndpointConfig.force_ssl?(%{"PHX_SCHEME" => "http", "FORCE_SSL" => "true"})
+    end
+  end
+
+  describe "check_origin/1" do
+    test "defaults to true, which validates against the resolved url config" do
+      assert EndpointConfig.check_origin(%{}) == true
+    end
+
+    test "can be disabled outright" do
+      assert EndpointConfig.check_origin(%{"PHX_CHECK_ORIGIN" => "false"}) == false
+    end
+
+    test "accepts an explicit comma-separated allow list" do
+      env = %{"PHX_CHECK_ORIGIN" => "http://192.168.5.99:8484,https://atlas.example.com"}
+
+      assert EndpointConfig.check_origin(env) ==
+               ["http://192.168.5.99:8484", "https://atlas.example.com"]
+    end
+
+    test "trims whitespace and drops empty entries in the allow list" do
+      env = %{"PHX_CHECK_ORIGIN" => " http://a.test , , https://b.test "}
+
+      assert EndpointConfig.check_origin(env) == ["http://a.test", "https://b.test"]
+    end
+  end
+
+  describe "skip_https_redirect?/1 (Plug.SSL runtime gate)" do
+    setup do
+      original = Application.get_env(:atlas, :force_ssl)
+      on_exit(fn -> Application.put_env(:atlas, :force_ssl, original) end)
+    end
+
+    test "does not skip while force_ssl is on" do
+      Application.put_env(:atlas, :force_ssl, true)
+
+      refute EndpointConfig.skip_https_redirect?(%Plug.Conn{})
+    end
+
+    test "skips every request once force_ssl is turned off at runtime" do
+      Application.put_env(:atlas, :force_ssl, false)
+
+      assert EndpointConfig.skip_https_redirect?(%Plug.Conn{})
+    end
+  end
+
+  describe "the shipped prod force_ssl config, driven through Plug.SSL" do
+    setup do
+      original = Application.get_env(:atlas, :force_ssl)
+      on_exit(fn -> Application.put_env(:atlas, :force_ssl, original) end)
+
+      opts =
+        "config/prod.exs"
+        |> Config.Reader.read!(env: :prod)
+        |> get_in([:atlas, AtlasWeb.Endpoint, :force_ssl])
+
+      {:ok, init: Plug.SSL.init(opts)}
+    end
+
+    test "redirects plain HTTP to HTTPS while force_ssl is on", %{init: init} do
+      Application.put_env(:atlas, :force_ssl, true)
+
+      out = Plug.SSL.call(conn(:get, "http://atlas.example.com/"), init)
+
+      assert out.status == 301
+      assert out.halted
+    end
+
+    test "serves plain HTTP untouched once FORCE_SSL is off", %{init: init} do
+      Application.put_env(:atlas, :force_ssl, false)
+
+      out = Plug.SSL.call(conn(:get, "http://192.168.5.99:8484/"), init)
+
+      refute out.halted
+      assert out.status == nil
+    end
+
+    test "localhost stays excluded regardless", %{init: init} do
+      Application.put_env(:atlas, :force_ssl, true)
+
+      out = Plug.SSL.call(conn(:get, "http://localhost:4000/"), init)
+
+      refute out.halted
+    end
+  end
+end

--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,13 @@ services:
       # Phoenix runtime. Migrations run automatically on boot.
       PHX_SERVER: "true"
       PHX_HOST: ${PHX_HOST:-localhost}
+      # Public scheme/port as clients see them. Defaults target a TLS-
+      # terminating proxy; set PHX_SCHEME=http (+ PHX_PORT) for a plain-HTTP
+      # LAN deployment, which also turns the HTTPS redirect off.
+      PHX_SCHEME: ${PHX_SCHEME:-}
+      PHX_PORT: ${PHX_PORT:-}
+      FORCE_SSL: ${FORCE_SSL:-}
+      PHX_CHECK_ORIGIN: ${PHX_CHECK_ORIGIN:-}
       PORT: "4000"
       SECRET_KEY_BASE: ${SECRET_KEY_BASE:-}
       # SQLite by default. For Postgres set DATABASE_URL=postgres://... AND use


### PR DESCRIPTION
Fixes #19.

## Problem

`config/runtime.exs` pinned `url: [host: host, port: 443, scheme: "https"]`. A headless LAN host reachable at `http://192.168.5.99:8484` therefore:

1. redirected to `https://192.168.5.99` (no port, wrong scheme), and
2. failed LiveView's origin check, since the endpoint derived `https://192.168.5.99` while the browser sent `Origin: http://192.168.5.99:8484`.

The map page *is* a LiveView, so (2) is the entire UI — meaning #19 is **not** resolved by the `X-Forwarded-Proto` fix in #29, which only addresses the proxy topology.

## Change

New `AtlasWeb.EndpointConfig` resolves the endpoint's public identity from the environment:

| Var | Default |
|---|---|
| `PHX_SCHEME` | `https` |
| `PHX_PORT` | 443, or 80 when scheme is http |
| `FORCE_SSL` | `true`, or `false` when `PHX_SCHEME=http` |
| `PHX_CHECK_ORIGIN` | `true` (validates against the resolved `url`) |

Setting `PHX_SCHEME=http` alone is enough for the LAN case: the redirect turns off, and because `url` now describes the real origin, `check_origin: true` validates correctly without an explicit allow list. `PHX_CHECK_ORIGIN` accepts `false` or a comma-separated list when the defaults don't cover every origin.

## The compile-time wrinkle

Phoenix reads `:force_ssl` with `Application.compile_env/2`, so `Plug.SSL` is baked into the endpoint at build time and `FORCE_SSL=false` cannot remove it. `Plug.SSL`'s `exclude: [conn: {m, f, a}]` callback *is* evaluated per request, so the runtime setting is applied through that instead.

## Interaction with #29

#29 hardcodes `header_up X-Forwarded-Proto https` in the Caddyfile, which asserts https even for a deliberately plain-HTTP LAN deployment. The two should be reconciled before both land — probably `{scheme}` plus `trusted_proxies` rather than a constant.

## Tests

```
411 tests, 0 failures
```

17 new: each env combination, plus the shipped **prod** `force_ssl` config driven through the real `Plug.SSL.call/2` — asserting a 301 while on, no redirect once off, and localhost excluded either way. The runtime wiring was additionally verified by evaluating `config/runtime.exs` through `Config.Reader` across all three deployment shapes.