### PR TITLE
Read the project .env when the control plane launches services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@
 #   will tell you when this is the case).
 # DOCKER_GID=999
 
+# ATLAS_ENV_FILE: where the in-app control plane reads THIS file from, as seen
+#   from inside the app container. Defaults to /work/.env, which compose.yml
+#   binds from the project root (`.:/work:ro`) — only change it if you mount the
+#   project somewhere else.
+# ATLAS_ENV_FILE=/work/.env
+
 # Region selection (ISO-2 country code; see Geofabrik for valid extracts)
 COUNTRY_CODE=de
 PBF_URL=https://download.geofabrik.de/europe/germany-latest.osm.pbf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- The in-app control plane now reads the project `.env`, so region, UID/GID and heap settings reach control-plane-launched services instead of silently falling back to compose defaults (#22)
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ## [Unreleased]
 
 ### Fixed
-- The in-app control plane now reads the project `.env`, so region, UID/GID and heap settings reach control-plane-launched services instead of silently falling back to compose defaults (#22)
+- The in-app control plane now reads the project `.env`, so region, UID/GID and heap settings reach control-plane-launched services instead of silently falling back to compose defaults (#22). Note: if your `.env` sets a different `COUNTRY_CODE` than the compose default, the next service start will now honour it and re-download that region's data.
 
 ## [0.3.0] - 2026-06-10
 

--- a/app-phoenix/lib/atlas/control/docker_compose.ex
+++ b/app-phoenix/lib/atlas/control/docker_compose.ex
@@ -13,6 +13,8 @@ defmodule Atlas.Control.DockerCompose do
 
   use GenServer
 
+  require Logger
+
   @type runner :: (String.t(), [String.t()] -> {Collectable.t(), exit_status :: non_neg_integer()})
   @type result :: {:ok, String.t()} | {:error, non_neg_integer(), String.t()}
 
@@ -84,6 +86,13 @@ defmodule Atlas.Control.DockerCompose do
     # bind-mounts the project root at /work, so point --env-file there.
     env_file = Keyword.get(opts, :env_file, default_env_file())
 
+    unless is_nil(env_file) or readable_file?(env_file) do
+      Logger.info(
+        "no readable #{env_file}; control-plane services will use compose defaults. " <>
+          "Settings from the project .env (region, UID/GID, heap) will not apply."
+      )
+    end
+
     {:ok, %{runner: runner, project_dir: project_dir, env_file: env_file}}
   end
 
@@ -105,18 +114,36 @@ defmodule Atlas.Control.DockerCompose do
   container sees it (`.:/work:ro` in compose.yml) rather than the host path in
   `--project-directory`. Override with `ATLAS_ENV_FILE`.
   """
-  def default_env_file, do: System.get_env("ATLAS_ENV_FILE") || "/work/.env"
+  def default_env_file do
+    case System.get_env("ATLAS_ENV_FILE") do
+      nil -> "/work/.env"
+      "" -> "/work/.env"
+      path -> path
+    end
+  end
+
+  @doc """
+  `--env-file` arguments for the default project `.env`, or `[]` when there
+  isn't a readable one. Shared with `Atlas.Control.LogTailer` so every compose
+  subcommand interpolates the compose file the same way.
+  """
+  def default_env_file_args, do: env_file_args(%{env_file: default_env_file()})
 
   defp project_args(%{project_dir: nil}), do: []
   defp project_args(%{project_dir: dir}), do: ["--project-directory", dir]
 
-  # Only pass the flag when the file is really there — compose errors out on a
-  # missing --env-file, and .env is optional.
+  # Only pass the flag when compose can actually read the file: it errors out on
+  # a missing --env-file, and .env is optional. Readability matters as much as
+  # existence — an unreadable file would turn a silent fallback into a hard stop.
   defp env_file_args(%{env_file: file}) when is_binary(file) do
-    if File.regular?(file), do: ["--env-file", file], else: []
+    if readable_file?(file), do: ["--env-file", file], else: []
   end
 
   defp env_file_args(_state), do: []
+
+  defp readable_file?(path) do
+    File.regular?(path) and match?({:ok, _}, File.open(path, [:read], &(&1)))
+  end
 
   defp host_project_dir do
     case System.get_env("HOST_PROJECT_DIR") do

--- a/app-phoenix/lib/atlas/control/docker_compose.ex
+++ b/app-phoenix/lib/atlas/control/docker_compose.ex
@@ -78,16 +78,18 @@ defmodule Atlas.Control.DockerCompose do
     # `--project-directory` handling.
     project_dir = Keyword.get(opts, :project_dir, host_project_dir())
 
-    {:ok, %{runner: runner, project_dir: project_dir}}
+    # `--project-directory` is a HOST path, so compose looks for the project's
+    # .env somewhere this container cannot see and every service silently comes
+    # up on compose defaults instead of the operator's settings. compose.yml
+    # bind-mounts the project root at /work, so point --env-file there.
+    env_file = Keyword.get(opts, :env_file, default_env_file())
+
+    {:ok, %{runner: runner, project_dir: project_dir, env_file: env_file}}
   end
 
   @impl true
   def handle_call({:compose, args}, _from, %{runner: runner} = state) do
-    full_args =
-      case state.project_dir do
-        nil -> ["compose" | args]
-        dir -> ["compose", "--project-directory", dir | args]
-      end
+    full_args = ["compose"] ++ project_args(state) ++ env_file_args(state) ++ args
 
     reply =
       case runner.("docker", full_args) do
@@ -97,6 +99,24 @@ defmodule Atlas.Control.DockerCompose do
 
     {:reply, reply, state}
   end
+
+  @doc """
+  Container-local path to the project `.env`, i.e. the project root as this
+  container sees it (`.:/work:ro` in compose.yml) rather than the host path in
+  `--project-directory`. Override with `ATLAS_ENV_FILE`.
+  """
+  def default_env_file, do: System.get_env("ATLAS_ENV_FILE") || "/work/.env"
+
+  defp project_args(%{project_dir: nil}), do: []
+  defp project_args(%{project_dir: dir}), do: ["--project-directory", dir]
+
+  # Only pass the flag when the file is really there — compose errors out on a
+  # missing --env-file, and .env is optional.
+  defp env_file_args(%{env_file: file}) when is_binary(file) do
+    if File.regular?(file), do: ["--env-file", file], else: []
+  end
+
+  defp env_file_args(_state), do: []
 
   defp host_project_dir do
     case System.get_env("HOST_PROJECT_DIR") do

--- a/app-phoenix/lib/atlas/control/log_tailer.ex
+++ b/app-phoenix/lib/atlas/control/log_tailer.ex
@@ -15,6 +15,7 @@ defmodule Atlas.Control.LogTailer do
   # `docker compose logs` in a tight loop when the CLI is broken.
   use GenServer, restart: :transient
 
+  alias Atlas.Control.DockerCompose
   alias Phoenix.PubSub
 
   @line_max_bytes 8192
@@ -48,7 +49,10 @@ defmodule Atlas.Control.LogTailer do
   compose project the host uses.
   """
   def default_args(name) do
-    ["compose"] ++ project_dir_args() ++ ["logs", "-f", "--tail=200", name]
+    ["compose"] ++
+      project_dir_args() ++
+      DockerCompose.default_env_file_args() ++
+      ["logs", "-f", "--tail=200", name]
   end
 
   defp project_dir_args do

--- a/app-phoenix/test/atlas/control/docker_compose_test.exs
+++ b/app-phoenix/test/atlas/control/docker_compose_test.exs
@@ -117,6 +117,29 @@ defmodule Atlas.Control.DockerComposeTest do
       assert args == ["compose", "--project-directory", "/srv/atlas", "up", "-d", "photon"]
     end
 
+    test "an unreadable .env is skipped rather than passed to compose", %{dir: dir} do
+      env_file = Path.join(dir, ".env")
+      File.write!(env_file, "COUNTRY_CODE=nl\n")
+      File.chmod!(env_file, 0o000)
+      on_exit(fn -> File.chmod(env_file, 0o600) end)
+
+      start_with(project_dir: "/srv/atlas", env_file: env_file)
+
+      assert {:ok, "ok"} = DockerCompose.start("photon")
+
+      assert_received {:stub, "docker", args}
+
+      refute "--env-file" in args,
+             "compose cannot read the file either, so passing it turns a silent fallback into a hard failure"
+    end
+
+    test "ATLAS_ENV_FILE set to empty is treated as unset" do
+      System.put_env("ATLAS_ENV_FILE", "")
+      on_exit(fn -> System.delete_env("ATLAS_ENV_FILE") end)
+
+      assert DockerCompose.default_env_file() == "/work/.env"
+    end
+
     test "defaults to the container-local mount of the project root", %{dir: dir} do
       env_file = Path.join(dir, ".env")
       File.write!(env_file, "COUNTRY_CODE=nl\n")

--- a/app-phoenix/test/atlas/control/docker_compose_test.exs
+++ b/app-phoenix/test/atlas/control/docker_compose_test.exs
@@ -71,6 +71,68 @@ defmodule Atlas.Control.DockerComposeTest do
                      ["compose", "--project-directory", "/srv/atlas", "up", "-d", "photon"]}
   end
 
+  describe "project .env" do
+    setup do
+      dir = Path.join(System.tmp_dir!(), "compose-env-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf!(dir) end)
+      {:ok, dir: dir}
+    end
+
+    defp start_with(opts) do
+      test_pid = self()
+      runner = fn cmd, args -> send(test_pid, {:stub, cmd, args}) && {"ok", 0} end
+      start_supervised!({DockerCompose, [runner: runner] ++ opts})
+    end
+
+    test "passes --env-file so services inherit the operator's .env", %{dir: dir} do
+      env_file = Path.join(dir, ".env")
+      File.write!(env_file, "COUNTRY_CODE=nl\n")
+
+      start_with(project_dir: "/srv/atlas", env_file: env_file)
+
+      assert {:ok, "ok"} = DockerCompose.start("photon")
+
+      assert_received {:stub, "docker", args}
+
+      assert args == [
+               "compose",
+               "--project-directory",
+               "/srv/atlas",
+               "--env-file",
+               env_file,
+               "up",
+               "-d",
+               "photon"
+             ]
+    end
+
+    test "omits --env-file when the project has no .env", %{dir: dir} do
+      start_with(project_dir: "/srv/atlas", env_file: Path.join(dir, ".env"))
+
+      assert {:ok, "ok"} = DockerCompose.start("photon")
+
+      assert_received {:stub, "docker", args}
+      refute "--env-file" in args
+      assert args == ["compose", "--project-directory", "/srv/atlas", "up", "-d", "photon"]
+    end
+
+    test "defaults to the container-local mount of the project root", %{dir: dir} do
+      env_file = Path.join(dir, ".env")
+      File.write!(env_file, "COUNTRY_CODE=nl\n")
+
+      # /work is where compose.yml bind-mounts the project root (`.:/work:ro`),
+      # so the .env the operator edited is readable from inside the container
+      # even though --project-directory names a host path.
+      assert DockerCompose.default_env_file() == "/work/.env"
+
+      start_with(project_dir: "/srv/atlas", env_file: env_file)
+      assert {:ok, "ok"} = DockerCompose.start("photon")
+      assert_received {:stub, "docker", args}
+      assert "--env-file" in args
+    end
+  end
+
   test "running?/1 is true when `compose ps` lists a running container" do
     start_compose({"3f2a1b\n", 0})
 

--- a/app-phoenix/test/atlas/control/log_tailer_test.exs
+++ b/app-phoenix/test/atlas/control/log_tailer_test.exs
@@ -51,6 +51,25 @@ defmodule Atlas.Control.LogTailerTest do
     assert args == ["compose", "logs", "-f", "--tail=200", "photon"]
   end
 
+  test "default args pass the same --env-file as DockerCompose" do
+    dir = Path.join(System.tmp_dir!(), "tailer-env-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    env_file = Path.join(dir, ".env")
+    File.write!(env_file, "COUNTRY_CODE=nl\n")
+    System.put_env("ATLAS_ENV_FILE", env_file)
+
+    on_exit(fn ->
+      System.delete_env("ATLAS_ENV_FILE")
+      File.rm_rf!(dir)
+    end)
+
+    args = LogTailer.default_args("photon")
+
+    assert Enum.chunk_every(args, 2, 1) |> Enum.member?(["--env-file", env_file]),
+           "compose interpolates the whole file for every subcommand; without --env-file " <>
+             "`logs` resolves variables differently from `up` and warns on each one"
+  end
+
   test "default args resolve the compose project against HOST_PROJECT_DIR" do
     System.put_env("HOST_PROJECT_DIR", "/srv/atlas")
     on_exit(fn -> System.delete_env("HOST_PROJECT_DIR") end)


### PR DESCRIPTION
Fixes #22.

## Problem

The control plane runs `docker compose --project-directory <HOST_PROJECT_DIR>`, and compose looks for `.env` **in the project directory** — a host path that does not exist inside the app container. So `.env` was never read, and every control-plane-launched service came up on compose defaults, silently ignoring the operator's settings in exactly the flow the UI steers people toward (Settings → enable).

Reported symptoms, all the same root cause:

- `COUNTRY_CODE=nl` ignored → Photon downloads Germany's index
- `UID`/`GID` ignored → whosonfirst runs as 1001 and dies on `EACCES`
- `OTP_JAVA_OPTS` ignored → OTP always builds at `-Xmx4g` and OOMs on a country-scale graph, with no working way to raise it

## Change

`compose.yml` already bind-mounts the project root at `/work` (`.:/work:ro`), so the `.env` the operator edited **is** readable from inside the container — just not at the host path in `--project-directory`. Pass it explicitly as `--env-file /work/.env` (override with `ATLAS_ENV_FILE`).

The flag is only added when the file actually exists, since compose errors out on a missing `--env-file` and `.env` is optional.

## Verification

Beyond the unit tests, confirmed against real `docker compose config` — the two symptoms from the issue, before and after:

```
── WITHOUT --env-file:            ── WITH --env-file:
   JAVA_OPTS: -Xmx4g ...             JAVA_OPTS: -Xmx12g
   REGION: de                        REGION: nl
```

## Tests

```
397 tests, 0 failures
```

New: the flag is passed when `.env` exists, omitted when it doesn't, and `default_env_file/0` points at the container-local mount.