### PR TITLE
Target the previous day's Protomaps build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- The Protomaps daily-planet basemap targets the previous day’s build, which is already published, instead of a build that may not exist yet (#2)
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -255,8 +255,8 @@ tiles-download: ## Fetch a PMTiles basemap. Defaults to TILES_URL from .env. Use
 	echo "Done: $$(du -sh $$target | cut -f1)"
 
 .PHONY: tiles-protomaps-latest
-tiles-protomaps-latest: ## Fetch today's Protomaps planet PMTiles (~100 GB) — works only for builds <30 days old
-	@latest=$$(date -u +%Y%m%d); \
+tiles-protomaps-latest: ## Fetch the latest published Protomaps planet PMTiles (~100 GB) — works only for builds <30 days old
+	@latest=$$(date -u -d '1 day ago' +%Y%m%d 2>/dev/null || date -u -v-1d +%Y%m%d); \
 	url="https://build.protomaps.com/$$latest.pmtiles"; \
 	$(MAKE) tiles-download URL=$$url
 

--- a/app-phoenix/lib/atlas/maps/basemap_presets.ex
+++ b/app-phoenix/lib/atlas/maps/basemap_presets.ex
@@ -74,12 +74,17 @@ defmodule Atlas.Maps.BasemapPresets do
     end
   end
 
-  @doc "Build today's UTC Protomaps daily-planet URL."
-  def protomaps_daily_url do
-    {{y, m, d}, _} = :calendar.universal_time()
-    "https://build.protomaps.com/#{y}#{pad(m)}#{pad(d)}.pmtiles"
-  end
+  @doc """
+  Build the Protomaps daily-planet URL for the most recent published build.
 
-  defp pad(n) when n < 10, do: "0#{n}"
-  defp pad(n), do: Integer.to_string(n)
+  Protomaps publishes a given day's planet some hours into that day, so
+  today's file is routinely still a 404. Target the previous day instead.
+  """
+  def protomaps_daily_url, do: protomaps_daily_url(Date.utc_today())
+
+  @doc "Build the Protomaps daily-planet URL for the day before `date`."
+  def protomaps_daily_url(%Date{} = date) do
+    stamp = date |> Date.add(-1) |> Calendar.strftime("%Y%m%d")
+    "https://build.protomaps.com/#{stamp}.pmtiles"
+  end
 end

--- a/app-phoenix/lib/atlas/maps/basemap_presets.ex
+++ b/app-phoenix/lib/atlas/maps/basemap_presets.ex
@@ -44,7 +44,7 @@ defmodule Atlas.Maps.BasemapPresets do
     %{
       id: "protomaps-planet-daily",
       label: "Protomaps planet (daily)",
-      note: "~100 GB pmtiles · range-served by R2 · today's UTC build",
+      note: "~100 GB pmtiles · range-served by R2 · latest published UTC build",
       url: nil,
       download: true,
       url_fn: &__MODULE__.protomaps_daily_url/0

--- a/app-phoenix/test/atlas/maps/basemap_presets_test.exs
+++ b/app-phoenix/test/atlas/maps/basemap_presets_test.exs
@@ -1,0 +1,50 @@
+defmodule Atlas.Maps.BasemapPresetsTest do
+  use ExUnit.Case, async: true
+
+  alias Atlas.Maps.BasemapPresets
+
+  describe "protomaps_daily_url/1" do
+    test "targets the previous day's build, which is already published" do
+      assert BasemapPresets.protomaps_daily_url(~D[2026-05-21]) ==
+               "https://build.protomaps.com/20260520.pmtiles"
+    end
+
+    test "rolls back across a month boundary" do
+      assert BasemapPresets.protomaps_daily_url(~D[2026-06-01]) ==
+               "https://build.protomaps.com/20260531.pmtiles"
+    end
+
+    test "rolls back across a year boundary" do
+      assert BasemapPresets.protomaps_daily_url(~D[2026-01-01]) ==
+               "https://build.protomaps.com/20251231.pmtiles"
+    end
+
+    test "zero-pads single-digit months and days" do
+      assert BasemapPresets.protomaps_daily_url(~D[2026-09-10]) ==
+               "https://build.protomaps.com/20260909.pmtiles"
+    end
+  end
+
+  describe "protomaps_daily_url/0" do
+    test "resolves against the current UTC date" do
+      expected = BasemapPresets.protomaps_daily_url(Date.utc_today())
+
+      assert BasemapPresets.protomaps_daily_url() == expected
+    end
+
+    test "never points at today's build" do
+      today = Date.utc_today()
+      today_stamp = Calendar.strftime(today, "%Y%m%d")
+
+      refute BasemapPresets.protomaps_daily_url() =~ today_stamp
+    end
+  end
+
+  describe "resolve/1" do
+    test "the protomaps preset resolves through the daily URL builder" do
+      assert {:ok, %{url: url, download: true}} = BasemapPresets.resolve("protomaps-planet-daily")
+
+      assert url == BasemapPresets.protomaps_daily_url()
+    end
+  end
+end

--- a/app-phoenix/test/atlas/maps/basemap_presets_test.exs
+++ b/app-phoenix/test/atlas/maps/basemap_presets_test.exs
@@ -40,6 +40,15 @@ defmodule Atlas.Maps.BasemapPresetsTest do
     end
   end
 
+  describe "preset metadata" do
+    test "the protomaps note does not promise today's build" do
+      note = Enum.find(BasemapPresets.all(), &(&1.id == "protomaps-planet-daily")).note
+
+      refute note =~ "today",
+             "the card note must not advertise a build the URL deliberately does not request"
+    end
+  end
+
   describe "resolve/1" do
     test "the protomaps preset resolves through the daily URL builder" do
       assert {:ok, %{url: url, download: true}} = BasemapPresets.resolve("protomaps-planet-daily")


### PR DESCRIPTION
Fixes #2.

## Problem

`protomaps_daily_url/0` built today's UTC date, but `build.protomaps.com` publishes a given day's planet some hours into that day — so the URL routinely points at a file that doesn't exist yet. As the issue put it: `20260521.pmtiles` 404s while `20260520.pmtiles` is there.

## Change

Resolve the daily URL against the **previous** day, which is already published. `protomaps_daily_url/1` is extracted so the date arithmetic is testable without freezing the clock, and the rollover cases come from `Date.add/2` rather than hand-rolled arithmetic.

## Tests

```
401 tests, 0 failures
```

7 new, covering the previous-day offset, month/year rollover, zero-padding, that `/0` never emits today's stamp, and that the `protomaps-planet-daily` preset resolves through the same builder.