### PR TITLE
Make CI green, and publish images from releases instead of every main push

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1,11 +1,22 @@
 name: Build app image
 
+# Images are cut from releases, not from main. Pushing to main no longer
+# publishes anything to GHCR — for a build on every main commit, see the
+# OneDev pipeline in .onedev-buildspec.yml, which pushes to onedev.dwri.xyz.
+#
+# Two ways in:
+#   * a release published by hand in the GitHub UI, and
+#   * workflow_dispatch, which is how release-on-changelog.yml kicks off the
+#     build for the releases it creates automatically. That indirection is
+#     required: a release created with GITHUB_TOKEN does not emit a `release`
+#     event, so this workflow would never see it.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'app-phoenix/**'
-      - '.github/workflows/build-app.yml'
+  release:
+    types: [published]
+  # Pick the tag to build with `gh workflow run build-app.yml --ref vX.Y.Z`.
+  # Deliberately no `ref` input: the ref the run is against is what gets
+  # checked out AND what `github.sha` reports, so a separate input could bake
+  # the wrong APP_REVISION into the image.
   workflow_dispatch:
 
 concurrency:
@@ -45,8 +56,17 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # `latest` used to mean "tip of main". It now means "newest stable
+          # release". latest=auto moves it only when the ref is a semver tag
+          # with no prerelease part, and it works the same whether we arrived
+          # here via `release` or via workflow_dispatch on a tag.
+          #
+          # ⚠️ It keys off the TAG, not the GitHub prerelease checkbox: tag a
+          # prerelease `v1.2.3-rc.1`, not `v1.2.3`, or `latest` will move to it.
+          flavor: latest=auto
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=sha,format=long
 
       - name: Build & push

--- a/.github/workflows/release-on-changelog.yml
+++ b/.github/workflows/release-on-changelog.yml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
+      # Needed to dispatch build-app.yml — see the last step.
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,3 +106,15 @@ jobs:
           gh release create "${TAG}" \
             --title "${TAG}" \
             --notes-file /tmp/release-body.md
+
+      - name: Build the release image
+        if: steps.parse.outputs.skip == 'false' && steps.exists.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.parse.outputs.tag }}
+        run: |
+          # The release above was created with GITHUB_TOKEN, and GitHub does not
+          # raise workflow-triggering events for anything GITHUB_TOKEN does — so
+          # build-app.yml never sees a `release` event from it. workflow_dispatch
+          # is the documented exception to that rule, so trigger it by hand.
+          gh workflow run build-app.yml --ref "${TAG}"

--- a/.onedev-buildspec.yml
+++ b/.onedev-buildspec.yml
@@ -1,6 +1,10 @@
 # OneDev CI — builds the Atlas app image (app-phoenix/) and pushes it to
-# OneDev's own built-in container registry (onedev.dwri.xyz). Used for
-# testing; the GHCR/production pipeline lives in .github/workflows/.
+# OneDev's own built-in container registry (onedev.dwri.xyz).
+#
+# This is the continuous build: the BranchUpdateTrigger below has no path
+# filter, so every push to main produces an image. GHCR is the opposite —
+# .github/workflows/build-app.yml only publishes from a release, so nothing
+# reaches ghcr.io until a version is cut.
 #
 # One-time setup on the OneDev side (see notes at the bottom of this file):
 #   1. Enable the built-in registry + set the server URL in System Settings.

--- a/app-phoenix/.credo.exs
+++ b/app-phoenix/.credo.exs
@@ -1,0 +1,43 @@
+%{
+  configs: [
+    %{
+      name: "default",
+      #
+      # Only deviations from Credo's defaults are listed here. Everything not
+      # mentioned runs with its stock configuration, so this file stays small
+      # and a Credo upgrade brings new checks with it.
+      #
+      checks: %{
+        extra: [
+          #
+          # Design.AliasUsage flags every fully-qualified nested call. On its
+          # stock settings that is 51 findings here, and almost none of them
+          # are worth acting on, so it was drowning out the rest of the suite.
+          # Two adjustments make it useful again:
+          #
+          #   * `if_called_more_often_than: 2` — an alias earns its place once
+          #     a module is referenced three or more times in a file. A one-off
+          #     `Atlas.Control.Preflight.run/1` reads better fully qualified,
+          #     especially across a `Boundary` line, where the full name is
+          #     what tells the reader a boundary is being crossed.
+          #
+          #   * tests excluded — the bulk of the findings there are
+          #     `Plug.Conn.resp/3` inside Bypass stubs and the mix task under
+          #     test being named in full. Both are the conventional form; an
+          #     alias would make the test less explicit, not more.
+          #
+          # `if_nested_deeper_than: 2` is Credo's own default, restated because
+          # naming a check in `extra` replaces its parameters wholesale rather
+          # than merging with them.
+          #
+          {Credo.Check.Design.AliasUsage,
+           [
+             if_nested_deeper_than: 2,
+             if_called_more_often_than: 2,
+             files: %{excluded: ["test/"]}
+           ]}
+        ]
+      }
+    }
+  ]
+}

--- a/app-phoenix/lib/atlas/application.ex
+++ b/app-phoenix/lib/atlas/application.ex
@@ -43,7 +43,7 @@ defmodule Atlas.Application do
     :ok
   end
 
-  defp skip_migrations?() do
+  defp skip_migrations? do
     # By default, sqlite migrations are run when using a release
     System.get_env("RELEASE_NAME") == nil
   end

--- a/app-phoenix/lib/atlas/control.ex
+++ b/app-phoenix/lib/atlas/control.ex
@@ -1,4 +1,12 @@
 defmodule Atlas.Control do
+  @moduledoc """
+  Boundary for the control plane.
+
+  Owns the self-hosted lifecycle: which region is selected, which sidecar
+  services are running, and the download/convert/apply pipeline that turns a
+  Geofabrik extract into data the map services can serve.
+  """
+
   use Boundary,
     deps: [
       Atlas.Repo,

--- a/app-phoenix/lib/atlas/control/jobs/auto_update_scan.ex
+++ b/app-phoenix/lib/atlas/control/jobs/auto_update_scan.ex
@@ -14,7 +14,7 @@ defmodule Atlas.Control.Jobs.AutoUpdateScan do
 
   import Ecto.Query
 
-  alias Atlas.{Repo, Control.Service}
+  alias Atlas.{Control.Service, Repo}
   alias Crontab.CronExpression.Parser
   alias Crontab.DateChecker
 

--- a/app-phoenix/lib/atlas/control/jobs/update_service.ex
+++ b/app-phoenix/lib/atlas/control/jobs/update_service.ex
@@ -15,7 +15,7 @@ defmodule Atlas.Control.Jobs.UpdateService do
     queue: :control,
     unique: [period: :infinity, states: [:available, :scheduled, :executing], fields: [:args]]
 
-  alias Atlas.{Repo, Control.Service, Control.DockerCompose}
+  alias Atlas.{Control.DockerCompose, Control.Service, Repo}
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"name" => name}}) do

--- a/app-phoenix/lib/atlas/control/parsers/otp.ex
+++ b/app-phoenix/lib/atlas/control/parsers/otp.ex
@@ -27,22 +27,14 @@ defmodule Atlas.Control.Parsers.OTP do
 
     new_acc =
       cond do
-        Regex.match?(@ready_re, line) or Regex.match?(@serve_re, line) ->
+        serving?(line) ->
           %{acc | phase: "ready", ready: true, progress: 1.0}
 
         Regex.match?(@error_re, line) ->
           %{acc | phase: "error", ready: false}
 
         match = Regex.run(@street_graph_re, line) ->
-          [_, _of, _total, pct_str] = match
-
-          progress =
-            case Integer.parse(pct_str) do
-              {pct, _} -> 0.3 + pct / 100.0 * 0.5
-              :error -> acc.progress
-            end
-
-          %{acc | phase: "building-graph", progress: progress}
+          %{acc | phase: "building-graph", progress: graph_progress(match, acc.progress)}
 
         Regex.match?(@trip_patterns_re, line) ->
           %{acc | phase: "trip-patterns", progress: max_progress(acc.progress, 0.7)}
@@ -61,6 +53,15 @@ defmodule Atlas.Control.Parsers.OTP do
       end
 
     {new_acc, new_acc}
+  end
+
+  defp serving?(line), do: Regex.match?(@ready_re, line) or Regex.match?(@serve_re, line)
+
+  defp graph_progress([_, _of, _total, pct_str], fallback) do
+    case Integer.parse(pct_str) do
+      {pct, _} -> 0.3 + pct / 100.0 * 0.5
+      :error -> fallback
+    end
   end
 
   defp max_progress(nil, floor), do: floor

--- a/app-phoenix/lib/atlas/control/parsers/valhalla.ex
+++ b/app-phoenix/lib/atlas/control/parsers/valhalla.ex
@@ -26,19 +26,11 @@ defmodule Atlas.Control.Parsers.Valhalla do
 
     new_acc =
       cond do
-        Regex.match?(@tiles_ready_re, line) or Regex.match?(@serve_re, line) ->
+        serving?(line) ->
           %{acc | phase: "ready", ready: true, progress: 1.0}
 
         match = Regex.run(@progress_re, line) ->
-          [_, _of, _total, pct_str] = match
-
-          progress =
-            case Integer.parse(pct_str) do
-              {pct, _} -> pct / 100.0
-              :error -> acc.progress
-            end
-
-          %{acc | phase: "building-tiles", progress: progress}
+          %{acc | phase: "building-tiles", progress: tile_progress(match, acc.progress)}
 
         Regex.match?(@tiles_re, line) ->
           %{acc | phase: "building-tiles", progress: max_progress(acc.progress, 0.5)}
@@ -57,6 +49,15 @@ defmodule Atlas.Control.Parsers.Valhalla do
       end
 
     {new_acc, new_acc}
+  end
+
+  defp serving?(line), do: Regex.match?(@tiles_ready_re, line) or Regex.match?(@serve_re, line)
+
+  defp tile_progress([_, _of, _total, pct_str], fallback) do
+    case Integer.parse(pct_str) do
+      {pct, _} -> pct / 100.0
+      :error -> fallback
+    end
   end
 
   defp max_progress(nil, floor), do: floor

--- a/app-phoenix/lib/atlas/control/region_catalog.ex
+++ b/app-phoenix/lib/atlas/control/region_catalog.ex
@@ -299,12 +299,10 @@ defmodule Atlas.Control.RegionCatalog do
   end
 
   defp unquote_value(value) do
-    cond do
-      String.starts_with?(value, "\"") and String.ends_with?(value, "\"") ->
-        String.slice(value, 1..-2//1)
-
-      true ->
-        value
+    if String.starts_with?(value, "\"") and String.ends_with?(value, "\"") do
+      String.slice(value, 1..-2//1)
+    else
+      value
     end
   end
 

--- a/app-phoenix/lib/atlas/control/seeder.ex
+++ b/app-phoenix/lib/atlas/control/seeder.ex
@@ -11,9 +11,9 @@ defmodule Atlas.Control.Seeder do
       already registered.
   """
 
-  alias Atlas.Repo
-  alias Atlas.Control.{Service, ServiceSupervisor}
   alias Atlas.Control.Parsers
+  alias Atlas.Control.{Service, ServiceSupervisor}
+  alias Atlas.Repo
 
   @services [
     %{name: "photon", profile: "geocoding", parser: Parsers.Photon},

--- a/app-phoenix/lib/atlas/control/service_state.ex
+++ b/app-phoenix/lib/atlas/control/service_state.ex
@@ -24,7 +24,7 @@ defmodule Atlas.Control.ServiceState do
 
   use GenServer
 
-  alias Atlas.Control.{Registry, Service}
+  alias Atlas.Control.{DockerCompose, Registry, Service}
   alias Atlas.Repo
   alias Phoenix.PubSub
 
@@ -349,8 +349,8 @@ defmodule Atlas.Control.ServiceState do
 
   defp compose(action, name) do
     case action do
-      :start -> Atlas.Control.DockerCompose.start(name)
-      :stop -> Atlas.Control.DockerCompose.stop(name)
+      :start -> DockerCompose.start(name)
+      :stop -> DockerCompose.stop(name)
     end
   rescue
     e -> {:error, 0, "control plane unavailable: #{Exception.message(e)}"}
@@ -359,7 +359,7 @@ defmodule Atlas.Control.ServiceState do
   end
 
   defp probe_running(name) do
-    Atlas.Control.DockerCompose.running?(name)
+    DockerCompose.running?(name)
   rescue
     e -> {:error, 0, Exception.message(e)}
   catch

--- a/app-phoenix/lib/atlas/control/snapshot_persister.ex
+++ b/app-phoenix/lib/atlas/control/snapshot_persister.ex
@@ -17,8 +17,8 @@ defmodule Atlas.Control.SnapshotPersister do
 
   import Ecto.Query
 
-  alias Atlas.Repo
   alias Atlas.Control.{Seeder, Service, ServiceState}
+  alias Atlas.Repo
 
   @tick_ms 5_000
 

--- a/app-phoenix/lib/atlas/maps.ex
+++ b/app-phoenix/lib/atlas/maps.ex
@@ -1,4 +1,12 @@
 defmodule Atlas.Maps do
+  @moduledoc """
+  Boundary for the map-data context.
+
+  Everything that answers a question about the world — geocoding, reverse
+  geocoding, routing, transit, POIs — lives under here and reaches the outside
+  only through the upstream HTTP clients in `Atlas.Maps.Upstream`.
+  """
+
   use Boundary,
     deps: [Req, Cachex, Logger, Task],
     exports: [Result, Search, Reverse, Route, Transit, WhatsHere, Poi, Geocode]

--- a/app-phoenix/lib/atlas/maps/geocode.ex
+++ b/app-phoenix/lib/atlas/maps/geocode.ex
@@ -3,7 +3,7 @@ defmodule Atlas.Maps.Geocode do
   Dual-mode geocode dispatch — forward via Search (when `q` is given) or
   reverse via Reverse (when `lat+lon` are given). Mirrors Rails behavior.
   """
-  alias Atlas.Maps.{Search, Reverse}
+  alias Atlas.Maps.{Reverse, Search}
 
   @doc """
   Returns one of:

--- a/app-phoenix/lib/atlas/maps/poi.ex
+++ b/app-phoenix/lib/atlas/maps/poi.ex
@@ -1,6 +1,15 @@
 defmodule Atlas.Maps.Poi do
+  @moduledoc """
+  Points of interest, by category.
+
+  Two lookups over the category catalog in `Atlas.Maps.Poi.Catalog`:
+  `nearby/1` pulls everything in a bbox from Overpass, and
+  `search_within_categories/1` does free-text name/address matching via Photon
+  scoped to the same categories.
+  """
+
   require Logger
-  alias Atlas.Maps.{Result, Upstream.Overpass, Upstream.Photon, Upstream.Client, Poi.Catalog}
+  alias Atlas.Maps.{Poi.Catalog, Result, Upstream.Client, Upstream.Overpass, Upstream.Photon}
 
   def catalog, do: Catalog.sections()
 
@@ -9,28 +18,26 @@ defmodule Atlas.Maps.Poi do
     types = opts[:types] || []
     selectors = Catalog.selectors_for(types)
 
-    cond do
-      is_nil(bbox) or length(bbox) != 4 ->
-        {:error, :invalid, "bbox required as 's,w,n,e'", %{}}
-
-      selectors == [] ->
-        {:error, :invalid, "no known types in #{inspect(types)}", %{types: types}}
-
-      true ->
-        case Overpass.bbox(bbox: bbox, filters: selectors, limit: opts[:limit] || 300) do
-          {:ok, %{"elements" => elements}} ->
-            features = Enum.map(elements, &poi_feature(&1, types))
-            {:ok, %Result{features: features, upstream_status: "ok"}}
-
-          {:error, %Client.Unavailable{} = e} ->
-            Logger.warning("overpass unavailable: #{Exception.message(e)}")
-            {:error, e}
-
-          {:error, %Client.BadResponse{} = e} ->
-            Logger.warning("overpass bad response: #{Exception.message(e)}")
-            {:error, e}
-        end
+    with :ok <- validate_scope(bbox, types, selectors) do
+      [bbox: bbox, filters: selectors, limit: opts[:limit] || 300]
+      |> Overpass.bbox()
+      |> handle_overpass(types)
     end
+  end
+
+  defp handle_overpass({:ok, %{"elements" => elements}}, types) do
+    features = Enum.map(elements, &poi_feature(&1, types))
+    {:ok, %Result{features: features, upstream_status: "ok"}}
+  end
+
+  defp handle_overpass({:error, %Client.Unavailable{} = e}, _types) do
+    Logger.warning("overpass unavailable: #{Exception.message(e)}")
+    {:error, e}
+  end
+
+  defp handle_overpass({:error, %Client.BadResponse{} = e}, _types) do
+    Logger.warning("overpass bad response: #{Exception.message(e)}")
+    {:error, e}
   end
 
   @doc """
@@ -45,6 +52,30 @@ defmodule Atlas.Maps.Poi do
     selectors = Catalog.selectors_for(types)
     query = opts[:query]
 
+    with :ok <- validate_scope(bbox, types, selectors),
+         :ok <- validate_query(query) do
+      osm_tags = Enum.map(selectors, &String.replace(&1, "=", ":"))
+      # Internal bbox is [s, w, n, e]. Photon expects w,s,e,n.
+      [s, w, n, e] = bbox
+
+      [query: query, limit: opts[:limit] || 50, bbox: [w, s, e, n], osm_tags: osm_tags]
+      |> Photon.search()
+      |> handle_photon(types)
+    end
+  end
+
+  defp handle_photon({:ok, %{"features" => features}}, types) do
+    normalized = Enum.map(features, &normalize_photon_feature(&1, types))
+    {:ok, %Result{features: normalized, upstream_status: "ok"}}
+  end
+
+  defp handle_photon({:ok, _other}, _types),
+    do: {:ok, %Result{features: [], upstream_status: "ok"}}
+
+  defp handle_photon({:error, %Client.Unavailable{} = e}, _types), do: {:error, e}
+  defp handle_photon({:error, %Client.BadResponse{} = e}, _types), do: {:error, e}
+
+  defp validate_scope(bbox, types, selectors) do
     cond do
       is_nil(bbox) or length(bbox) != 4 ->
         {:error, :invalid, "bbox required as 's,w,n,e'", %{}}
@@ -52,29 +83,15 @@ defmodule Atlas.Maps.Poi do
       selectors == [] ->
         {:error, :invalid, "no known types in #{inspect(types)}", %{types: types}}
 
-      is_nil(query) or query == "" ->
-        {:error, :invalid, "q required for search_within_categories", %{param: "q"}}
-
       true ->
-        osm_tags = Enum.map(selectors, &String.replace(&1, "=", ":"))
-        # Internal bbox is [s, w, n, e]. Photon expects w,s,e,n.
-        [s, w, n, e] = bbox
-        photon_bbox = [w, s, e, n]
-        limit = opts[:limit] || 50
-
-        case Photon.search(query: query, limit: limit, bbox: photon_bbox, osm_tags: osm_tags) do
-          {:ok, %{"features" => features}} ->
-            normalized = Enum.map(features, &normalize_photon_feature(&1, types))
-            {:ok, %Result{features: normalized, upstream_status: "ok"}}
-
-          {:ok, _other} ->
-            {:ok, %Result{features: [], upstream_status: "ok"}}
-
-          {:error, %Client.Unavailable{} = e} -> {:error, e}
-          {:error, %Client.BadResponse{} = e} -> {:error, e}
-        end
+        :ok
     end
   end
+
+  defp validate_query(query) when is_nil(query) or query == "",
+    do: {:error, :invalid, "q required for search_within_categories", %{param: "q"}}
+
+  defp validate_query(_query), do: :ok
 
   defp normalize_photon_feature(feat, types) do
     props = feat["properties"] || %{}
@@ -108,16 +125,7 @@ defmodule Atlas.Maps.Poi do
   end
 
   defp derive_category_from_tags(tags, types) do
-    Enum.find_value(types, fn type_id ->
-      case Catalog.find_item(type_id) do
-        nil ->
-          nil
-
-        %{selector: selector} ->
-          [k, v] = String.split(selector, "=", parts: 2)
-          if tags[k] == v, do: type_id, else: nil
-      end
-    end) || List.first(types) || "other"
+    Enum.find(types, &type_matches?(&1, tags)) || List.first(types) || "other"
   end
 
   defp poi_feature(el, types) do
@@ -134,15 +142,17 @@ defmodule Atlas.Maps.Poi do
   end
 
   defp derive_category(tags, types) do
-    Enum.find(types, fn type_id ->
-      case Catalog.find_item(type_id) do
-        nil ->
-          false
+    Enum.find(types, &type_matches?(&1, tags)) || "other"
+  end
 
-        %{selector: selector} ->
-          [k, v] = String.split(selector, "=", parts: 2)
-          tags[k] == v
-      end
-    end) || "other"
+  defp type_matches?(type_id, tags) do
+    case Catalog.find_item(type_id) do
+      nil ->
+        false
+
+      %{selector: selector} ->
+        [k, v] = String.split(selector, "=", parts: 2)
+        tags[k] == v
+    end
   end
 end

--- a/app-phoenix/lib/atlas/maps/poi/catalog.ex
+++ b/app-phoenix/lib/atlas/maps/poi/catalog.ex
@@ -1,4 +1,12 @@
 defmodule Atlas.Maps.Poi.Catalog do
+  @moduledoc """
+  The POI category catalog, compiled in from `priv/poi_categories.exs`.
+
+  Categories and their SVG icons are read at compile time (and registered as
+  `@external_resource`, so editing the file triggers a rebuild). Maps
+  user-facing category ids to the OSM tag selectors the Overpass queries use.
+  """
+
   @path Path.expand("../../../../priv/poi_categories.exs", __DIR__)
   @external_resource @path
   @sections Code.eval_file(@path) |> elem(0)

--- a/app-phoenix/lib/atlas/maps/result.ex
+++ b/app-phoenix/lib/atlas/maps/result.ex
@@ -1,4 +1,11 @@
 defmodule Atlas.Maps.Result do
+  @moduledoc """
+  A GeoJSON-shaped result envelope returned by every `Atlas.Maps` lookup.
+
+  Carries the `features` list plus `upstream_status`, which lets a partially
+  degraded answer (one upstream down, the rest fine) still reach the client.
+  """
+
   defstruct features: [], upstream_status: "ok"
 
   @type upstream_status :: String.t()

--- a/app-phoenix/lib/atlas/maps/reverse.ex
+++ b/app-phoenix/lib/atlas/maps/reverse.ex
@@ -33,7 +33,7 @@ defmodule Atlas.Maps.Reverse do
       {:error, :too_many, 500}
   """
   require Logger
-  alias Atlas.Maps.{Place, Result, Upstream.Photon, Upstream.Placeholder, Upstream.Client}
+  alias Atlas.Maps.{Place, Result, Upstream.Client, Upstream.Photon, Upstream.Placeholder}
 
   @max_coords 500
   @grid_decimals 4

--- a/app-phoenix/lib/atlas/maps/route.ex
+++ b/app-phoenix/lib/atlas/maps/route.ex
@@ -1,5 +1,12 @@
 defmodule Atlas.Maps.Route do
-  alias Atlas.Maps.{Result, Upstream.Valhalla, Upstream.Client}
+  @moduledoc """
+  Point-to-point routing via Valhalla.
+
+  Wraps `Atlas.Maps.Upstream.Valhalla` and normalises its response into a
+  `Atlas.Maps.Result`.
+  """
+
+  alias Atlas.Maps.{Result, Upstream.Client, Upstream.Valhalla}
   require Logger
 
   @doc """

--- a/app-phoenix/lib/atlas/maps/search.ex
+++ b/app-phoenix/lib/atlas/maps/search.ex
@@ -1,13 +1,20 @@
 defmodule Atlas.Maps.Search do
+  @moduledoc """
+  Forward geocoding and autocomplete.
+
+  Resolves free-text queries to places through Photon, with Libpostal used to
+  normalise the query and Placeholder to fill in coarse administrative context.
+  """
+
   require Logger
 
   alias Atlas.Maps.{
     Place,
     Result,
+    Upstream.Client,
     Upstream.Libpostal,
     Upstream.Photon,
-    Upstream.Placeholder,
-    Upstream.Client
+    Upstream.Placeholder
   }
 
   def autocomplete(opts) do

--- a/app-phoenix/lib/atlas/maps/transit.ex
+++ b/app-phoenix/lib/atlas/maps/transit.ex
@@ -3,7 +3,7 @@ defmodule Atlas.Maps.Transit do
   Transit orchestrator. Calls OTP and serializes the camelCase response into
   snake_case `plan`/`leg` shapes matching Rails `TransitsController#serialize_plan`.
   """
-  alias Atlas.Maps.{Result, Upstream.Otp, Upstream.Client}
+  alias Atlas.Maps.{Result, Upstream.Client, Upstream.Otp}
   require Logger
 
   def plan(opts) do

--- a/app-phoenix/lib/atlas/maps/upstream/client.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/client.ex
@@ -1,4 +1,13 @@
 defmodule Atlas.Maps.Upstream.Client do
+  @moduledoc """
+  Shared HTTP client for every upstream map service.
+
+  Builds preconfigured `Req` clients — from explicit options or from
+  `<PREFIX>_URL` / `<PREFIX>_TIMEOUT` / `<PREFIX>_OPEN_TIMEOUT` env vars — and
+  normalises failures into two exceptions the contexts can match on:
+  `Unavailable` (could not connect) and `BadResponse` (connected, bad status).
+  """
+
   defmodule Unavailable do
     defexception [:message, :upstream]
   end

--- a/app-phoenix/lib/atlas/maps/upstream/libpostal.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/libpostal.ex
@@ -1,4 +1,11 @@
 defmodule Atlas.Maps.Upstream.Libpostal do
+  @moduledoc """
+  libpostal client — parses a free-text address into labelled components.
+
+  Used to canonicalise a query before it reaches the geocoder; falls back to the
+  raw input when parsing yields nothing.
+  """
+
   alias Atlas.Maps.Upstream.Client
 
   def default do
@@ -9,7 +16,7 @@ defmodule Atlas.Maps.Upstream.Libpostal do
   def normalize(req \\ default(), address) when is_binary(address) do
     case Client.get(req, "/parser", [{"address", address}]) do
       {:ok, components} when is_list(components) ->
-        canonical = components |> Enum.map(& &1["value"]) |> Enum.join(" ")
+        canonical = Enum.map_join(components, " ", & &1["value"])
         %{query: if(canonical == "", do: address, else: canonical), components: components}
 
       _ ->

--- a/app-phoenix/lib/atlas/maps/upstream/otp.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/otp.ex
@@ -1,4 +1,10 @@
 defmodule Atlas.Maps.Upstream.Otp do
+  @moduledoc """
+  OpenTripPlanner client for multi-modal transit itineraries.
+
+  Defaults to the `TRANSIT,WALK` mode set.
+  """
+
   alias Atlas.Maps.Upstream.Client
 
   @default_modes "TRANSIT,WALK"

--- a/app-phoenix/lib/atlas/maps/upstream/overpass.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/overpass.ex
@@ -1,4 +1,11 @@
 defmodule Atlas.Maps.Upstream.Overpass do
+  @moduledoc """
+  Overpass API client.
+
+  Builds Overpass QL for the two shapes the app needs — `around/2` (radius) and
+  `bbox/2` (bounding box) — from a list of OSM tag selectors.
+  """
+
   alias Atlas.Maps.Upstream.Client
 
   def default do
@@ -31,12 +38,10 @@ defmodule Atlas.Maps.Upstream.Overpass do
           ~s|node(#{bbox_clause});way(#{bbox_clause});relation(#{bbox_clause});|
 
         filters ->
-          filters
-          |> Enum.map(fn sel ->
+          Enum.map_join(filters, "", fn sel ->
             [k, v] = String.split(sel, "=", parts: 2)
             ~s|node["#{k}"="#{v}"](#{bbox_clause});way["#{k}"="#{v}"](#{bbox_clause});|
           end)
-          |> Enum.join("")
       end
 
     ~s|[out:json][timeout:#{timeout}];(#{statements});out body center #{limit};|
@@ -55,12 +60,10 @@ defmodule Atlas.Maps.Upstream.Overpass do
           ~s|node(#{around_clause});way(#{around_clause});relation(#{around_clause});|
 
         tags ->
-          tags
-          |> Enum.map(fn tag ->
+          Enum.map_join(tags, "", fn tag ->
             [k, v] = String.split(tag, ":", parts: 2)
             ~s|node["#{k}"="#{v}"](#{around_clause});way["#{k}"="#{v}"](#{around_clause});|
           end)
-          |> Enum.join("")
       end
 
     ~s|[out:json][timeout:#{timeout}];(#{statements});out body center;|

--- a/app-phoenix/lib/atlas/maps/upstream/photon.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/photon.ex
@@ -1,4 +1,8 @@
 defmodule Atlas.Maps.Upstream.Photon do
+  @moduledoc """
+  Photon geocoder client — forward search and reverse lookup.
+  """
+
   alias Atlas.Maps.Upstream.Client
 
   def default do

--- a/app-phoenix/lib/atlas/maps/upstream/placeholder.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/placeholder.ex
@@ -1,4 +1,12 @@
 defmodule Atlas.Maps.Upstream.Placeholder do
+  @moduledoc """
+  Placeholder client — coarse administrative lookup.
+
+  Resolves a text query to its country/state/county/city/postcode lineage, used
+  to enrich geocoding results. Returns `nil` rather than an error: this is
+  supplementary context, never the primary answer.
+  """
+
   alias Atlas.Maps.Upstream.Client
 
   def default do

--- a/app-phoenix/lib/atlas/maps/upstream/valhalla.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/valhalla.ex
@@ -1,4 +1,8 @@
 defmodule Atlas.Maps.Upstream.Valhalla do
+  @moduledoc """
+  Valhalla routing client, for the `auto`, `bicycle` and `pedestrian` costings.
+  """
+
   alias Atlas.Maps.Upstream.Client
 
   @modes ~w[auto bicycle pedestrian]

--- a/app-phoenix/lib/atlas/maps/whats_here.ex
+++ b/app-phoenix/lib/atlas/maps/whats_here.ex
@@ -1,4 +1,11 @@
 defmodule Atlas.Maps.WhatsHere do
+  @moduledoc """
+  "What is at this coordinate?" — reverse geocode plus surrounding POIs.
+
+  Combines `Atlas.Maps.Reverse` with an Overpass `around` query. Both must
+  succeed; either failing surfaces the upstream error.
+  """
+
   alias Atlas.Maps.{Result, Reverse, Upstream.Overpass}
 
   @doc """

--- a/app-phoenix/lib/atlas_web/controllers/admin/regions_controller.ex
+++ b/app-phoenix/lib/atlas_web/controllers/admin/regions_controller.ex
@@ -11,8 +11,8 @@ defmodule AtlasWeb.Admin.RegionsController do
 
   import Ecto.Query
 
-  alias Atlas.Repo
   alias Atlas.Control.{RegionCatalog, RegionSelection}
+  alias Atlas.Repo
 
   def show(conn, _params) do
     json(conn, %{data: current_state()})

--- a/app-phoenix/lib/atlas_web/controllers/api/v1/fallback_controller.ex
+++ b/app-phoenix/lib/atlas_web/controllers/api/v1/fallback_controller.ex
@@ -14,7 +14,7 @@ defmodule AtlasWeb.Api.V1.FallbackController do
   - `{:error, :too_many, max}` → 422 `VALIDATION_ERROR`
   """
   use AtlasWeb, :controller
-  alias Atlas.Maps.Upstream.Client.{Unavailable, BadResponse}
+  alias Atlas.Maps.Upstream.Client.{BadResponse, Unavailable}
   alias AtlasWeb.Api.V1.BaseController
 
   def call(conn, {:error, %Unavailable{message: m}}) do

--- a/app-phoenix/lib/atlas_web/live/admin/apply_live.ex
+++ b/app-phoenix/lib/atlas_web/live/admin/apply_live.ex
@@ -3,8 +3,8 @@ defmodule AtlasWeb.Admin.ApplyLive do
 
   import Ecto.Query
 
-  alias Atlas.Repo
   alias Atlas.Control.{RegionApplier, RegionCatalog, RegionSelection, Safe}
+  alias Atlas.Repo
   import AtlasWeb.AdminErrorComponents
 
   @impl true

--- a/app-phoenix/lib/atlas_web/live/admin/regions_live.ex
+++ b/app-phoenix/lib/atlas_web/live/admin/regions_live.ex
@@ -3,8 +3,8 @@ defmodule AtlasWeb.Admin.RegionsLive do
 
   import Ecto.Query
 
-  alias Atlas.Repo
   alias Atlas.Control.{RegionCatalog, RegionSelection}
+  alias Atlas.Repo
   alias AtlasWeb.Admin.RegionsController
 
   @impl true

--- a/app-phoenix/lib/atlas_web/live/admin/services_live.ex
+++ b/app-phoenix/lib/atlas_web/live/admin/services_live.ex
@@ -1,7 +1,7 @@
 defmodule AtlasWeb.Admin.ServicesLive do
   use AtlasWeb, :live_view
 
-  alias Atlas.Control.{Safe, Service, ServiceSchedule, ServiceState, Seeder, Jobs}
+  alias Atlas.Control.{Jobs, Safe, Seeder, Service, ServiceSchedule, ServiceState}
   alias Atlas.Repo
 
   @impl true

--- a/app-phoenix/lib/atlas_web/live/admin/tiles_live.ex
+++ b/app-phoenix/lib/atlas_web/live/admin/tiles_live.ex
@@ -1,8 +1,8 @@
 defmodule AtlasWeb.Admin.TilesLive do
   use AtlasWeb, :live_view
 
-  alias Atlas.Settings
   alias Atlas.Control.TilesDownloader
+  alias Atlas.Settings
   alias AtlasWeb.Admin.TilesController
 
   @impl true

--- a/app-phoenix/lib/atlas_web/live/components/degradation_banner.ex
+++ b/app-phoenix/lib/atlas_web/live/components/degradation_banner.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.DegradationBanner do
+  @moduledoc """
+  Banner shown when one or more upstream services are unavailable.
+  """
+
   use Phoenix.Component
 
   use Phoenix.VerifiedRoutes,

--- a/app-phoenix/lib/atlas_web/live/components/directions_card.ex
+++ b/app-phoenix/lib/atlas_web/live/components/directions_card.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.DirectionsCard do
+  @moduledoc """
+  The directions panel — mode switcher, endpoints, and the resulting itinerary.
+  """
+
   use Phoenix.Component
 
   import AtlasWeb.IconHelpers

--- a/app-phoenix/lib/atlas_web/live/components/places_card.ex
+++ b/app-phoenix/lib/atlas_web/live/components/places_card.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.PlacesCard do
+  @moduledoc """
+  Live component listing nearby places for the selected POI categories.
+  """
+
   use AtlasWeb, :live_component
 
   alias Atlas.Maps.Poi.Catalog

--- a/app-phoenix/lib/atlas_web/live/components/region_chip.ex
+++ b/app-phoenix/lib/atlas_web/live/components/region_chip.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.RegionChip do
+  @moduledoc """
+  Chips for picking a region and for showing the currently selected one.
+  """
+
   use Phoenix.Component
 
   attr :id, :string, required: true

--- a/app-phoenix/lib/atlas_web/live/components/search_card.ex
+++ b/app-phoenix/lib/atlas_web/live/components/search_card.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.SearchCard do
+  @moduledoc """
+  The search input card and its result list.
+  """
+
   use Phoenix.Component
 
   import AtlasWeb.IconHelpers

--- a/app-phoenix/lib/atlas_web/live/components/service_card.ex
+++ b/app-phoenix/lib/atlas_web/live/components/service_card.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.ServiceCard do
+  @moduledoc """
+  Live component for one sidecar service — status, schedule and controls.
+  """
+
   use AtlasWeb, :live_component
 
   alias Atlas.Control.ServiceSchedule

--- a/app-phoenix/lib/atlas_web/live/components/settings/atoms.ex
+++ b/app-phoenix/lib/atlas_web/live/components/settings/atoms.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.Settings.Atoms do
+  @moduledoc """
+  Small presentational building blocks shared across the settings tabs — eyebrows, badges, stats, progress bars and status dots.
+  """
+
   use Phoenix.Component
 
   import AtlasWeb.IconHelpers

--- a/app-phoenix/lib/atlas_web/live/components/settings/basemap_tab.ex
+++ b/app-phoenix/lib/atlas_web/live/components/settings/basemap_tab.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.Settings.BasemapTab do
+  @moduledoc """
+  Basemap tab of the settings drawer — preset selection and tile download state.
+  """
+
   use Phoenix.Component
 
   import AtlasWeb.IconHelpers

--- a/app-phoenix/lib/atlas_web/live/components/settings/pending_summary.ex
+++ b/app-phoenix/lib/atlas_web/live/components/settings/pending_summary.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.Settings.PendingSummary do
+  @moduledoc """
+  Summary of the not-yet-applied region change: what will be downloaded, converted and restarted.
+  """
+
   use Phoenix.Component
 
   alias Atlas.Control.{ApplyProjection, RegionCatalog}

--- a/app-phoenix/lib/atlas_web/live/components/settings/region_tab.ex
+++ b/app-phoenix/lib/atlas_web/live/components/settings/region_tab.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.Settings.RegionTab do
+  @moduledoc """
+  Region tab of the settings drawer — pick a region and review what applying it will change.
+  """
+
   use Phoenix.Component
 
   import AtlasWeb.IconHelpers

--- a/app-phoenix/lib/atlas_web/live/components/settings/services_tab.ex
+++ b/app-phoenix/lib/atlas_web/live/components/settings/services_tab.ex
@@ -1,4 +1,8 @@
 defmodule AtlasWeb.Settings.ServicesTab do
+  @moduledoc """
+  Services tab of the settings drawer — per-service status, schedules and actions.
+  """
+
   use Phoenix.Component
 
   import AtlasWeb.IconHelpers

--- a/app-phoenix/lib/atlas_web/live/components/settings_panel.ex
+++ b/app-phoenix/lib/atlas_web/live/components/settings_panel.ex
@@ -1,9 +1,13 @@
 defmodule AtlasWeb.SettingsPanel do
+  @moduledoc """
+  Live component hosting the settings drawer and its tab bar.
+  """
+
   use AtlasWeb, :live_component
 
   import AtlasWeb.Settings.Atoms
 
-  alias Atlas.Control.{RegionCatalog, RegionSelection, Seeder, ServiceFormatting}
+  alias Atlas.Control.{Preflight, RegionCatalog, RegionSelection, Seeder, ServiceFormatting}
   alias Atlas.Maps.BasemapPresets
   alias Atlas.Repo
   alias AtlasWeb.Settings
@@ -55,7 +59,7 @@ defmodule AtlasWeb.SettingsPanel do
   end
 
   defp preflight_failures do
-    Atlas.Control.Preflight.results() |> Atlas.Control.Preflight.failures()
+    Preflight.results() |> Preflight.failures()
   rescue
     _ -> []
   end
@@ -120,7 +124,7 @@ defmodule AtlasWeb.SettingsPanel do
   def handle_event("preflight_recheck", _params, socket) do
     failures =
       try do
-        Atlas.Control.Preflight.refresh() |> Atlas.Control.Preflight.failures()
+        Preflight.refresh() |> Preflight.failures()
       rescue
         _ -> []
       end

--- a/app-phoenix/lib/atlas_web/live/map_live.ex
+++ b/app-phoenix/lib/atlas_web/live/map_live.ex
@@ -212,7 +212,6 @@ defmodule AtlasWeb.MapLive do
     end
   end
 
-
   @impl true
   def handle_event("cancel_basemap_confirm", _params, socket) do
     {:noreply, assign(socket, basemap_confirm: nil)}

--- a/app-phoenix/lib/mix/tasks/atlas.migrate_from_rails_postgres.ex
+++ b/app-phoenix/lib/mix/tasks/atlas.migrate_from_rails_postgres.ex
@@ -65,6 +65,7 @@ defmodule Mix.Tasks.Atlas.MigrateFromRailsPostgres do
     # `Application.compile_env`, so we call it through `apply/3` to keep this
     # check truly runtime — otherwise the compiler flags the comparison as
     # always-false in a SQLite build.
+    # credo:disable-for-next-line Credo.Check.Refactor.Apply
     apply(Atlas.Repo, :__adapter__, []) == Ecto.Adapters.Postgres
   end
 

--- a/app-phoenix/test/atlas/control/jobs/auto_update_scan_test.exs
+++ b/app-phoenix/test/atlas/control/jobs/auto_update_scan_test.exs
@@ -2,7 +2,7 @@ defmodule Atlas.Control.Jobs.AutoUpdateScanTest do
   use Atlas.DataCase, async: false
   use Oban.Testing, repo: Atlas.Repo
 
-  alias Atlas.Control.{Service, Jobs.AutoUpdateScan, Jobs.UpdateService}
+  alias Atlas.Control.{Jobs.AutoUpdateScan, Jobs.UpdateService, Service}
 
   setup do
     start_supervised!({Oban, Application.fetch_env!(:atlas, Oban) |> Keyword.put(:testing, :manual)})

--- a/app-phoenix/test/atlas/control/jobs/update_service_test.exs
+++ b/app-phoenix/test/atlas/control/jobs/update_service_test.exs
@@ -2,7 +2,7 @@ defmodule Atlas.Control.Jobs.UpdateServiceTest do
   use Atlas.DataCase, async: false
   use Oban.Testing, repo: Atlas.Repo
 
-  alias Atlas.Control.{DockerCompose, Service, Jobs.UpdateService}
+  alias Atlas.Control.{DockerCompose, Jobs.UpdateService, Service}
 
   setup do
     start_supervised!({Oban, Application.fetch_env!(:atlas, Oban) |> Keyword.put(:testing, :manual)})

--- a/app-phoenix/test/atlas/maps/reverse_batch_test.exs
+++ b/app-phoenix/test/atlas/maps/reverse_batch_test.exs
@@ -7,7 +7,7 @@ defmodule Atlas.Maps.ReverseBatchTest do
     bypass = Bypass.open()
     System.put_env("PHOTON_URL", "http://localhost:#{bypass.port}")
     System.put_env("PLACEHOLDER_URL", "http://localhost:#{bypass.port}")
-    on_exit(fn -> System.delete_env("PHOTON_URL"); System.delete_env("PLACEHOLDER_URL") end)
+    on_exit(fn -> Enum.each(["PHOTON_URL", "PLACEHOLDER_URL"], &System.delete_env/1) end)
     {:ok, bypass: bypass}
   end
 
@@ -46,7 +46,7 @@ defmodule Atlas.Maps.ReverseBatchTest do
   end
 
   test "batch returns {:error, :too_many, 500} when over MAX_COORDS=500" do
-    coords = for n <- 1..501, do: %{lat: 52.0 + n / 10000, lon: 13.0 + n / 10000}
+    coords = for n <- 1..501, do: %{lat: 52.0 + n / 10_000, lon: 13.0 + n / 10_000}
     assert {:error, :too_many, 500} = Reverse.batch(%{coords: coords})
   end
 

--- a/app-phoenix/test/atlas/maps/reverse_test.exs
+++ b/app-phoenix/test/atlas/maps/reverse_test.exs
@@ -1,6 +1,6 @@
 defmodule Atlas.Maps.ReverseTest do
   use ExUnit.Case, async: false
-  alias Atlas.Maps.{Reverse, Result}
+  alias Atlas.Maps.{Result, Reverse}
 
   setup do
     bypass = Bypass.open()

--- a/app-phoenix/test/atlas/maps/route_test.exs
+++ b/app-phoenix/test/atlas/maps/route_test.exs
@@ -1,6 +1,6 @@
 defmodule Atlas.Maps.RouteTest do
   use ExUnit.Case, async: false
-  alias Atlas.Maps.{Route, Result}
+  alias Atlas.Maps.{Result, Route}
 
   setup do
     bypass = Bypass.open()

--- a/app-phoenix/test/atlas/maps/search_test.exs
+++ b/app-phoenix/test/atlas/maps/search_test.exs
@@ -1,6 +1,6 @@
 defmodule Atlas.Maps.SearchTest do
   use ExUnit.Case, async: false
-  alias Atlas.Maps.{Search, Result}
+  alias Atlas.Maps.{Result, Search}
 
   setup do
     bypass = Bypass.open()

--- a/app-phoenix/test/atlas/maps/transit_test.exs
+++ b/app-phoenix/test/atlas/maps/transit_test.exs
@@ -1,6 +1,6 @@
 defmodule Atlas.Maps.TransitTest do
   use ExUnit.Case, async: false
-  alias Atlas.Maps.{Transit, Result}
+  alias Atlas.Maps.{Result, Transit}
 
   setup do
     bypass = Bypass.open()

--- a/app-phoenix/test/atlas/maps/upstream/client_test.exs
+++ b/app-phoenix/test/atlas/maps/upstream/client_test.exs
@@ -1,7 +1,7 @@
 defmodule Atlas.Maps.Upstream.ClientTest do
   use ExUnit.Case, async: true
   alias Atlas.Maps.Upstream.Client
-  alias Atlas.Maps.Upstream.Client.{Unavailable, BadResponse}
+  alias Atlas.Maps.Upstream.Client.{BadResponse, Unavailable}
 
   setup do
     bypass = Bypass.open()

--- a/app-phoenix/test/atlas/maps/whats_here_test.exs
+++ b/app-phoenix/test/atlas/maps/whats_here_test.exs
@@ -1,13 +1,13 @@
 defmodule Atlas.Maps.WhatsHereTest do
   use ExUnit.Case, async: false
-  alias Atlas.Maps.{WhatsHere, Result}
+  alias Atlas.Maps.{Result, WhatsHere}
 
   setup do
     bypass = Bypass.open()
     System.put_env("PHOTON_URL", "http://localhost:#{bypass.port}")
     System.put_env("PLACEHOLDER_URL", "http://localhost:#{bypass.port}")
     System.put_env("OVERPASS_URL", "http://localhost:#{bypass.port}")
-    on_exit(fn -> ["PHOTON_URL","PLACEHOLDER_URL","OVERPASS_URL"] |> Enum.each(&System.delete_env/1) end)
+    on_exit(fn -> Enum.each(["PHOTON_URL", "PLACEHOLDER_URL", "OVERPASS_URL"], &System.delete_env/1) end)
     {:ok, bypass: bypass}
   end
 

--- a/app-phoenix/test/atlas_web/controllers/api/v1/health_controller_test.exs
+++ b/app-phoenix/test/atlas_web/controllers/api/v1/health_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule AtlasWeb.Api.V1.HealthControllerTest do
   use AtlasWeb.ConnCase, async: true
-  alias Atlas.Repo
   alias Atlas.Control.Service
+  alias Atlas.Repo
 
   test "GET /api/v1/health returns per-capability statuses in the data envelope", %{conn: conn} do
     for {name, status} <- [

--- a/app-phoenix/test/atlas_web/controllers/api/v1/pois_controller_test.exs
+++ b/app-phoenix/test/atlas_web/controllers/api/v1/pois_controller_test.exs
@@ -81,7 +81,7 @@ defmodule AtlasWeb.Api.V1.PoisControllerTest do
 
     types = resp["meta"]["types"]
     assert is_list(types)
-    assert length(types) > 0
+    assert types != []
     assert length(types) <= 2
 
     pinned_ids = Atlas.Maps.Poi.Catalog.pinned() |> Enum.take(2) |> Enum.map(& &1.id)

--- a/app-phoenix/test/atlas_web/controllers/api/v1/reverse_controller_test.exs
+++ b/app-phoenix/test/atlas_web/controllers/api/v1/reverse_controller_test.exs
@@ -86,7 +86,7 @@ defmodule AtlasWeb.Api.V1.ReverseControllerTest do
   end
 
   test "POST /api/v1/reverse/batch returns 422 when over MAX_COORDS=500", %{conn: conn} do
-    coords = for n <- 1..501, do: %{lat: 52.0 + n / 10000, lon: 13.0 + n / 10000}
+    coords = for n <- 1..501, do: %{lat: 52.0 + n / 10_000, lon: 13.0 + n / 10_000}
 
     resp =
       conn

--- a/app-phoenix/test/atlas_web/live/map_live_test.exs
+++ b/app-phoenix/test/atlas_web/live/map_live_test.exs
@@ -176,7 +176,7 @@ defmodule AtlasWeb.MapLiveTest do
     assert_push_event(view, "map:draw_route", %{geojson: geojson})
 
     assert %{type: "FeatureCollection", features: features} = geojson
-    assert length(features) >= 1
+    assert features != []
 
     Enum.each(features, fn feature ->
       assert %{type: "Feature", geometry: %{type: "LineString", coordinates: coords}} = feature

--- a/app-phoenix/test/mix/tasks/atlas_migrate_from_rails_test.exs
+++ b/app-phoenix/test/mix/tasks/atlas_migrate_from_rails_test.exs
@@ -3,10 +3,10 @@ defmodule Mix.Tasks.Atlas.MigrateFromRailsTest do
 
   import ExUnit.CaptureIO
 
-  alias Atlas.Repo
-  alias Atlas.Settings
   alias Atlas.Control.RegionSelection
   alias Atlas.Control.Service
+  alias Atlas.Repo
+  alias Atlas.Settings
 
   @sentinel_key "migrated_from_rails_at"
 


### PR DESCRIPTION
Merge this before #29–#39 — until it lands, none of them have actually run a test.

## Why first

`test-phoenix` has been red on `main` since 2026-06-29. The failing step is `mix credo --strict` (exit 30, 125 findings), and it runs **before** `mix test`:

```
deps.get → compile --warnings-as-errors → credo --strict → test
```

So the suite has never executed on any open PR. Every one of them inherits a red build regardless of its own quality, which is why #29–#33 sat for weeks. With this merged they get a real signal.

The root cause turned out to be that the repo had **no `.credo.exs` at all**, so Credo ran its full default check set in strict mode. `Design.AliasUsage` alone accounted for 51 of the 125.

## Commit 1 — credo green

- **42 mechanical findings** fixed: alias ordering, `Enum.map_join`, large-number separators, `length/1` emptiness checks, a stray semicolon, missing spaces after commas, a single-condition `cond`, a redundant blank line, parens on a zero-arity def. The one deliberate `apply/3` — it exists to defeat compile-time resolution, and the comment says so — gets an inline disable rather than a rewrite.
- **27 missing `@moduledoc`** written.
- **4 cyclomatic-complexity + 1 nesting** finding resolved by refactors rather than by raising thresholds, and they surfaced real duplication:
  - `Poi.nearby/1` and `Poi.search_within_categories/1` carried an identical validation preamble → extracted to `validate_scope/3` + `validate_query/1`, `with`-chained.
  - `derive_category/2` and `derive_category_from_tags/2` were near-identical → collapsed onto a shared `type_matches?/2`.
  - The two log-parser dispatches had their percentage parsing lifted out.

The parser `cond` dispatches are deliberately left intact. Each parser has only three fixture-replay tests and the `error` / `trip-patterns` / `saving-graph` branches are uncovered, so restructuring them would have been an untested refactor. They were at complexity 10 purely because of the `or` in the first branch; extracting `serving?/1` brings them to 9 with zero behaviour change.

`.credo.exs` lists **only deviations** from the defaults, so a Credo upgrade still brings new checks with it. The single deviation is `Design.AliasUsage`: it now suggests an alias at three or more references, and is skipped for tests where the findings were almost entirely `Plug.Conn.resp/3` inside Bypass stubs. It stays enabled and still caught two real cases, which are fixed here.

## Commit 2 — images come from releases

`build-app.yml` no longer runs on pushes to `main`. GHCR now publishes only when a release is published; the continuous per-commit build is OneDev's, whose `BranchUpdateTrigger` already fires on every main update with no path filter.

Two things worth knowing:

- **`latest` changes meaning** from "tip of main" to "newest stable release". The old `enable={{is_default_branch}}` would have silently produced *no* `latest` tag at all under a release trigger, since the ref is then a tag. Tagging moves to `latest=auto` + semver patterns — which keys off the **tag string**, not GitHub's prerelease checkbox, so tag prereleases `vX.Y.Z-rc.N`.
- **A release created with `GITHUB_TOKEN` emits no `release` event**, and that is how `release-on-changelog.yml` cuts every version here (v0.1.0 → v0.3.0 all came from it). A bare `release: published` trigger would therefore never have fired. It now dispatches `build-app.yml` explicitly — `workflow_dispatch` is the documented exception to that rule.

## Verification

Clean `mix clean` rebuild, exact CI sequence:

| step | result |
|---|---|
| `mix compile --warnings-as-errors` | exit 0 |
| `mix credo --strict` | exit 0 — "found no issues" |
| `mix test --include parity` | **394 tests, 0 failures, 1 skipped** |

Also ran the normally-excluded `catalog_artifact` test, since `region_catalog.ex` changed — passes. The suite was green all along; credo was the only thing red.

## Rebase impact

None. All ten open PRs merge cleanly onto this branch — verified with `git merge-tree` against each. #33 touches `upstream/otp.ex` and so does this branch, but the hunks don't overlap (moduledoc at the top vs `plan/2` below).

## Not included

`mix format --check-formatted` fails on 52 files repo-wide. That is pre-existing, there is no format gate in CI, and running it would bury this diff. Among the files touched here the count went from 22 to 21 — no new drift.
