### PR TITLE
feat: add map matching API (POST /api/v1/map-match)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,14 @@ WHOSONFIRST_COUNTRY_CODE=de
 
 # Set to False to skip SRTM download in Valhalla (saves ~3–30 GB per region).
 BUILD_ELEVATION=True
+
+# Map matching (POST /api/v1/map-match). Both are optional.
+#
+# MAP_MATCH_MAX_POINTS: largest trace accepted in one request (default 10000).
+#   Matching is superlinear in point count and occupies a Valhalla worker for
+#   the whole request, so lower this on a shared instance.
+# VALHALLA_MATCH_TIMEOUT: milliseconds to wait for a match (default 60000).
+#   Deliberately separate from the routing timeout — a full-day trace takes
+#   far longer than an A-to-B route.
+# MAP_MATCH_MAX_POINTS=10000
+# VALHALLA_MATCH_TIMEOUT=60000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Overpass diff updates are now opt-in so POIs can serve after an initial import without waiting on Geofabrik catch-up (#27)
 - Dokploy's minimal compose file no longer starts or exposes Overpass by default; the Overpass service and `/overpass` proxy are now commented out together as optional poster-sidecar configuration.
 
+### Added
+- **Map matching** — `POST /api/v1/map-match` snaps a recorded GPS trace onto the road network via Valhalla's Meili matcher, the inverse of `/api/v1/route`: routing invents a path between two points, matching takes a path you already walked and decides which edges you were on. Post a `shape` of `{lat, lon}` points (optionally with `time` and `accuracy`); `mode`, `shape_match` and Valhalla's `search_radius` / `gps_accuracy` / `breakage_distance` are accepted. `format=polyline6` (default) returns Valhalla's legs verbatim, matching what `/api/v1/route` already returns; `format=geojson` stitches them into one decoded `LineString`, so callers need no polyline decoder of their own. A trace Valhalla cannot match — outside the loaded region, or too sparse or too noisy — is reported as invalid input rather than as an upstream failure. Trace length is capped by `MAP_MATCH_MAX_POINTS` (default 10000), and matching gets its own `VALHALLA_MATCH_TIMEOUT` (default 60000 ms) separate from the routing timeout, since it is superlinear in point count and holds a Valhalla worker for the whole request.
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/app-phoenix/lib/atlas/maps/map_match.ex
+++ b/app-phoenix/lib/atlas/maps/map_match.ex
@@ -1,0 +1,140 @@
+defmodule Atlas.Maps.MapMatch do
+  @moduledoc """
+  Snap a recorded GPS trace onto the road network via Valhalla's Meili
+  matcher (`/trace_route`).
+
+  This is the inverse of `Atlas.Maps.Route`: routing invents a path between
+  two points, matching takes a path you already walked and decides which edges
+  you were actually on.
+
+  Two output shapes, chosen with `:format`:
+
+    * `"polyline6"` (default) — Valhalla's legs verbatim, each carrying an
+      encoded `shape`. Matches what `/api/v1/route` returns.
+    * `"geojson"` — legs decoded and stitched into one `LineString`, so
+      callers need no polyline decoder of their own.
+  """
+
+  alias Atlas.Geometry.Polyline
+  alias Atlas.Maps.{Result, Upstream.Client, Upstream.Valhalla}
+
+  require Logger
+
+  @min_points 2
+  @max_points 10_000
+  @polyline_precision 6
+
+  @doc """
+  Upper bound on trace length, overridable with `MAP_MATCH_MAX_POINTS`.
+
+  Matching is superlinear in point count and holds a Valhalla worker for the
+  whole request, so an unbounded trace is a denial-of-service on a shared
+  instance.
+  """
+  def max_points, do: Client.env_int("MAP_MATCH_MAX_POINTS", @max_points)
+
+  @doc "Smallest trace that can be matched."
+  def min_points, do: @min_points
+
+  @doc """
+  Match `:shape` — a list of `%{lat:, lon:}` maps, optionally with `:time`
+  and `:accuracy` — onto the road network.
+
+  Returns `{:ok, %Result{}}`, or one of the error tuples
+  `AtlasWeb.Api.V1.FallbackController` knows how to render.
+  """
+  def match(opts) do
+    shape = opts[:shape] || []
+
+    with :ok <- validate_shape(shape),
+         {:ok, body} <- request(shape, opts) do
+      {:ok, build_result(body, opts[:format])}
+    end
+  end
+
+  defp validate_shape(shape) do
+    count = length(shape)
+    max = max_points()
+
+    cond do
+      count < @min_points ->
+        {:error, :invalid, "shape must have at least #{@min_points} points",
+         %{param: "shape", min: @min_points}}
+
+      count > max ->
+        {:error, :too_many, max}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp request(shape, opts) do
+    Valhalla.trace_route(
+      shape: shape,
+      mode: opts[:mode] || "auto",
+      shape_match: opts[:shape_match],
+      trace_options: opts[:trace_options]
+    )
+    |> handle_response()
+  end
+
+  # Valhalla answers 400 when no road network candidate fits the trace
+  # (error_code 171, "No suitable edges near location"). That is unmatchable
+  # input, not a sick upstream — surfacing it as 502 sends the operator
+  # debugging a service that is behaving correctly.
+  defp handle_response({:ok, body}), do: {:ok, body}
+
+  defp handle_response({:error, %Client.BadResponse{status: 400}}) do
+    {:error, :invalid,
+     "the trace could not be matched to the road network — it may lie outside " <>
+       "the loaded region, or the points may be too sparse or too noisy", %{param: "shape"}}
+  end
+
+  defp handle_response({:error, %Client.Unavailable{} = error}) do
+    Logger.warning("valhalla unavailable: #{Exception.message(error)}")
+    {:error, error}
+  end
+
+  defp handle_response({:error, %Client.BadResponse{} = error}) do
+    Logger.warning("valhalla bad response: #{Exception.message(error)}")
+    {:error, error}
+  end
+
+  defp build_result(body, "geojson") do
+    trip = body["trip"] || %{}
+
+    %Result{
+      features: %{
+        summary: trip["summary"] || %{},
+        geometry: %{type: "LineString", coordinates: coordinates(trip["legs"] || [])},
+        shape_format: "geojson"
+      },
+      upstream_status: "ok"
+    }
+  end
+
+  defp build_result(body, _format) do
+    trip = body["trip"] || %{}
+
+    %Result{
+      features: %{
+        summary: trip["summary"] || %{},
+        legs: trip["legs"] || [],
+        shape_format: "valhalla_encoded_polyline6"
+      },
+      upstream_status: "ok"
+    }
+  end
+
+  # Valhalla repeats the boundary vertex at the end of one leg and the start of
+  # the next, so a flat concatenation emits it twice. `Enum.dedup/1` drops only
+  # consecutive repeats, which is exactly the seam and never a genuine
+  # stationary stretch elsewhere in the trace.
+  defp coordinates(legs) do
+    legs
+    |> Enum.flat_map(&Polyline.decode(&1["shape"] || "", @polyline_precision))
+    |> Enum.dedup()
+    |> Enum.map(fn {lat, lon} -> [lon, lat] end)
+  end
+end

--- a/app-phoenix/lib/atlas/maps/upstream/valhalla.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/valhalla.ex
@@ -1,16 +1,39 @@
 defmodule Atlas.Maps.Upstream.Valhalla do
   @moduledoc """
-  Valhalla routing client, for the `auto`, `bicycle` and `pedestrian` costings.
+  Valhalla client for point-to-point routing (`/route`) and map matching
+  (`/trace_route`), over the `auto`, `bicycle` and `pedestrian` costings.
   """
 
   alias Atlas.Maps.Upstream.Client
 
   @modes ~w[auto bicycle pedestrian]
+  @shape_matches ~w[map_snap edge_walk walk_or_snap]
+  @trace_option_keys ~w[search_radius gps_accuracy breakage_distance]a
+
+  @default_url "http://localhost:8004"
+  @match_timeout 60_000
 
   def default do
-    Client.build_from_env("VALHALLA", "http://localhost:8004",
-                          timeout: 15_000, open_timeout: 2_000)
+    Client.build_from_env("VALHALLA", @default_url, timeout: 15_000, open_timeout: 2_000)
   end
+
+  @doc """
+  Client for `/trace_route`, which needs a far longer receive timeout than
+  `default/0`: matching a multi-thousand-point trace is minutes of work where
+  an A-to-B route is milliseconds. Override with `VALHALLA_MATCH_TIMEOUT`.
+  """
+  def match_default do
+    Client.build(System.get_env("VALHALLA_URL") || @default_url,
+      timeout: Client.env_int("VALHALLA_MATCH_TIMEOUT", @match_timeout),
+      open_timeout: Client.env_int("VALHALLA_OPEN_TIMEOUT", 2_000)
+    )
+  end
+
+  @doc "Costings this client accepts. Valhalla has no rail or ferry costing."
+  def modes, do: @modes
+
+  @doc "Accepted `shape_match` strategies."
+  def shape_matches, do: @shape_matches
 
   def route(req \\ default(), opts) do
     mode = opts[:mode] || "auto"
@@ -28,6 +51,61 @@ defmodule Atlas.Maps.Upstream.Valhalla do
 
     Client.post(req, "/route", body)
   end
+
+  @doc """
+  Map-match a recorded trace onto the road network.
+
+  `:shape` is a list of `%{lat:, lon:}` maps, optionally carrying `:time`
+  (epoch seconds) and `:accuracy` (metres) — both materially improve the
+  match, since Meili weights candidate edges by GPS noise and elapsed time.
+
+  Returns the same `{"trip" => ...}` envelope as `route/2`.
+  """
+  def trace_route(req \\ nil, opts) do
+    req = req || match_default()
+    mode = opts[:mode] || "auto"
+    shape_match = opts[:shape_match] || "map_snap"
+
+    unless mode in @modes, do: raise(ArgumentError, "invalid mode #{mode}")
+
+    unless shape_match in @shape_matches do
+      raise(ArgumentError, "invalid shape_match #{shape_match}")
+    end
+
+    body =
+      %{
+        shape: Enum.map(opts[:shape] || [], &shape_point/1),
+        costing: mode,
+        shape_match: shape_match,
+        directions_options: %{units: "kilometers"}
+      }
+      |> maybe_add_trace_options(opts[:trace_options])
+
+    Client.post(req, "/trace_route", body)
+  end
+
+  # Only the keys actually present are emitted: Valhalla rejects a null `time`
+  # on a shape point, so a nil-filled map is worse than an absent key.
+  defp shape_point(point) do
+    point
+    |> Map.take([:lat, :lon, :time, :accuracy])
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Map.new()
+  end
+
+  defp maybe_add_trace_options(body, %{} = options) when map_size(options) > 0 do
+    trace_options =
+      options
+      |> Map.take(@trace_option_keys)
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+
+    if map_size(trace_options) > 0,
+      do: Map.put(body, :trace_options, trace_options),
+      else: body
+  end
+
+  defp maybe_add_trace_options(body, _options), do: body
 
   defp maybe_add_costing_options(body, "auto", %{} = options) when map_size(options) > 0 do
     auto_opts =

--- a/app-phoenix/lib/atlas_web/controllers/api/v1/map_match_controller.ex
+++ b/app-phoenix/lib/atlas_web/controllers/api/v1/map_match_controller.ex
@@ -1,0 +1,161 @@
+defmodule AtlasWeb.Api.V1.MapMatchController do
+  @moduledoc """
+  `POST /api/v1/map-match` — snap a recorded GPS trace onto the road network.
+
+  A POST rather than a GET like `/route`: a trace is thousands of points, far
+  past what a query string can carry.
+  """
+
+  use AtlasWeb.Api.V1.BaseController
+  action_fallback AtlasWeb.Api.V1.FallbackController
+
+  alias Atlas.Maps.MapMatch
+  alias Atlas.Maps.Upstream.Valhalla
+  alias AtlasWeb.Schemas
+
+  import OpenApiSpex.Operation, only: [response: 3]
+
+  @formats ~w(polyline6 geojson)
+  @trace_option_params ~w(search_radius gps_accuracy breakage_distance)a
+
+  operation(:create,
+    summary: "Map-match a recorded GPS trace onto the road network",
+    description: """
+    Takes the points you actually recorded and returns the road geometry you
+    were on. `shape` is an array of `{lat, lon}` objects, optionally carrying
+    `time` (epoch seconds) and `accuracy` (metres) — supplying both materially
+    improves the match.
+
+    Set `format` to `geojson` to get a decoded `LineString` instead of
+    Valhalla's encoded polyline legs.
+    """,
+    request_body:
+      {"Map match request", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         required: [:shape],
+         properties: %{
+           shape: %OpenApiSpex.Schema{type: :array, description: "Recorded points, in order"},
+           mode: %OpenApiSpex.Schema{type: :string, enum: Valhalla.modes()},
+           shape_match: %OpenApiSpex.Schema{type: :string, enum: Valhalla.shape_matches()},
+           format: %OpenApiSpex.Schema{type: :string, enum: @formats},
+           search_radius: %OpenApiSpex.Schema{type: :number},
+           gps_accuracy: %OpenApiSpex.Schema{type: :number},
+           breakage_distance: %OpenApiSpex.Schema{type: :number}
+         }
+       }},
+    responses: %{
+      200 => response("Matched trace", "application/json", Schemas.Response),
+      400 => response("Missing shape", "application/json", Schemas.Error),
+      422 => response("Invalid or unmatchable trace", "application/json", Schemas.Error),
+      502 => response("Upstream error", "application/json", Schemas.Error),
+      503 => response("Upstream unavailable", "application/json", Schemas.Error)
+    }
+  )
+
+  def create(conn, %{"shape" => raw_shape} = params) when is_list(raw_shape) do
+    with {:ok, shape} <- parse_shape(raw_shape),
+         {:ok, mode} <- parse_enum(params["mode"], Valhalla.modes(), "mode", "auto"),
+         {:ok, shape_match} <-
+           parse_enum(params["shape_match"], Valhalla.shape_matches(), "shape_match", "map_snap"),
+         {:ok, format} <- parse_enum(params["format"], @formats, "format", "polyline6"),
+         {:ok, result} <-
+           MapMatch.match(
+             shape: shape,
+             mode: mode,
+             shape_match: shape_match,
+             format: format,
+             trace_options: trace_options(params)
+           ) do
+      json(conn, %{
+        data: result.features,
+        meta:
+          meta(conn, %{
+            mode: mode,
+            shape_match: shape_match,
+            format: format,
+            points: length(shape),
+            max_points: MapMatch.max_points()
+          })
+      })
+    end
+  end
+
+  def create(_conn, _params), do: {:error, :missing, "shape"}
+
+  # Validated here rather than deeper down so the response can name the exact
+  # index that failed: with a few thousand points, "a point is invalid" is not
+  # an actionable error message.
+  defp parse_shape(raw_shape) do
+    raw_shape
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, &collect_point/2)
+    |> finish_shape()
+  end
+
+  defp collect_point({raw, index}, {:ok, acc}) do
+    case parse_point(raw) do
+      {:ok, point} -> {:cont, {:ok, [point | acc]}}
+      :error -> {:halt, invalid_point(index)}
+    end
+  end
+
+  defp finish_shape({:ok, points}), do: {:ok, Enum.reverse(points)}
+  defp finish_shape(error), do: error
+
+  defp invalid_point(index) do
+    {:error, :invalid, "shape[#{index}] must have numeric lat and lon",
+     %{param: "shape", index: index}}
+  end
+
+  defp parse_point(%{"lat" => lat, "lon" => lon} = raw) do
+    case {parse_float(lat), parse_float(lon)} do
+      {lat_f, lon_f} when is_number(lat_f) and is_number(lon_f) ->
+        {:ok,
+         %{
+           lat: lat_f,
+           lon: lon_f,
+           time: parse_number(raw["time"]),
+           accuracy: parse_number(raw["accuracy"])
+         }}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp parse_point(_raw), do: :error
+
+  defp trace_options(params) do
+    Map.new(@trace_option_params, fn key ->
+      {key, parse_number(params[Atom.to_string(key)])}
+    end)
+  end
+
+  # Integers are preserved rather than coerced to floats: Valhalla's
+  # `breakage_distance` and `time` are whole units, and a float there reads as
+  # spurious precision in the request Atlas forwards.
+  defp parse_number(value) when is_number(value), do: value
+
+  defp parse_number(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> int
+      _ -> parse_float(value)
+    end
+  end
+
+  defp parse_number(_value), do: nil
+
+  defp parse_enum(value, allowed, name, default) do
+    cond do
+      value in [nil, ""] -> {:ok, default}
+      is_binary(value) and value in allowed -> {:ok, value}
+      true -> enum_error(allowed, name)
+    end
+  end
+
+  defp enum_error(allowed, name) do
+    {:error, :invalid, "#{name} must be one of #{Enum.join(allowed, ", ")}",
+     %{param: name, allowed: allowed}}
+  end
+end

--- a/app-phoenix/lib/atlas_web/router.ex
+++ b/app-phoenix/lib/atlas_web/router.ex
@@ -26,6 +26,7 @@ defmodule AtlasWeb.Router do
     get "/reverse", ReverseController, :show
     post "/reverse/batch", ReverseController, :batch
     get "/route", RouteController, :show
+    post "/map-match", MapMatchController, :create
     get "/transit", TransitController, :show
     get "/whats-here", WhatsHereController, :index
     get "/pois", PoisController, :index

--- a/app-phoenix/test/atlas/maps/map_match_test.exs
+++ b/app-phoenix/test/atlas/maps/map_match_test.exs
@@ -1,0 +1,128 @@
+defmodule Atlas.Maps.MapMatchTest do
+  use ExUnit.Case, async: false
+
+  alias Atlas.Maps.MapMatch
+  alias Atlas.Maps.Upstream.Client
+
+  # Verified against Atlas.Geometry.Polyline.decode(_, 6):
+  #   LEG_A -> [{52.5, 13.4}, {52.51, 13.41}]
+  #   LEG_B -> [{52.51, 13.41}, {52.52, 13.42}]
+  # The legs deliberately share {52.51, 13.41} — Valhalla repeats the boundary
+  # point in each leg, and a naive concatenation would emit it twice.
+  @leg_a "_ajccB_{zpX_pR_pR"
+  @leg_b "_r}ccB_lnqX_pR_pR"
+
+  @shape [%{lat: 52.5, lon: 13.4}, %{lat: 52.51, lon: 13.41}, %{lat: 52.52, lon: 13.42}]
+
+  setup do
+    bypass = Bypass.open()
+    System.put_env("VALHALLA_URL", "http://localhost:#{bypass.port}")
+    on_exit(fn -> System.delete_env("VALHALLA_URL") end)
+    {:ok, bypass: bypass}
+  end
+
+  defp respond(bypass, status, body) do
+    Bypass.expect_once(bypass, "POST", "/trace_route", fn conn ->
+      Plug.Conn.resp(conn, status, body)
+    end)
+  end
+
+  describe "match/1" do
+    test "normalises the trip envelope into a Result", %{bypass: bypass} do
+      respond(bypass, 200, ~s({"trip":{"summary":{"length":2.5},"legs":[{"shape":"#{@leg_a}"}]}}))
+
+      assert {:ok, result} = MapMatch.match(shape: @shape, mode: "auto")
+
+      assert result.features.summary == %{"length" => 2.5}
+      assert [%{"shape" => @leg_a}] = result.features.legs
+      assert result.features.shape_format == "valhalla_encoded_polyline6"
+      assert result.upstream_status == "ok"
+    end
+
+    test "rejects a trace with fewer than two points", %{bypass: _bypass} do
+      assert {:error, :invalid, message, details} =
+               MapMatch.match(shape: [%{lat: 52.5, lon: 13.4}], mode: "auto")
+
+      assert message =~ "at least 2"
+      assert details == %{param: "shape", min: 2}
+    end
+
+    test "rejects a trace over the point cap" do
+      over = MapMatch.max_points() + 1
+      shape = for _ <- 1..over, do: %{lat: 52.5, lon: 13.4}
+
+      assert {:error, :too_many, max} = MapMatch.match(shape: shape, mode: "auto")
+      assert max == MapMatch.max_points()
+    end
+
+    test "max_points/0 is overridable via MAP_MATCH_MAX_POINTS" do
+      System.put_env("MAP_MATCH_MAX_POINTS", "7")
+      on_exit(fn -> System.delete_env("MAP_MATCH_MAX_POINTS") end)
+
+      assert MapMatch.max_points() == 7
+    end
+  end
+
+  describe "geojson output" do
+    test "decodes the legs into a single LineString of [lon, lat]", %{bypass: bypass} do
+      respond(bypass, 200, ~s({"trip":{"summary":{},"legs":[{"shape":"#{@leg_a}"}]}}))
+
+      assert {:ok, result} = MapMatch.match(shape: @shape, mode: "auto", format: "geojson")
+
+      assert result.features.shape_format == "geojson"
+
+      assert result.features.geometry == %{
+               type: "LineString",
+               coordinates: [[13.4, 52.5], [13.41, 52.51]]
+             }
+
+      # The encoded legs are redundant once decoded, and shipping both doubles
+      # the payload for the exact consumer that asked not to decode anything.
+      refute Map.has_key?(result.features, :legs)
+    end
+
+    test "joins consecutive legs without repeating the shared boundary point", %{bypass: bypass} do
+      respond(
+        bypass,
+        200,
+        ~s({"trip":{"summary":{},"legs":[{"shape":"#{@leg_a}"},{"shape":"#{@leg_b}"}]}})
+      )
+
+      assert {:ok, result} = MapMatch.match(shape: @shape, mode: "auto", format: "geojson")
+
+      assert result.features.geometry.coordinates == [
+               [13.4, 52.5],
+               [13.41, 52.51],
+               [13.42, 52.52]
+             ]
+    end
+  end
+
+  describe "upstream failures" do
+    test "a 400 becomes a validation error, not a bad gateway", %{bypass: bypass} do
+      # Valhalla answers 400 when the trace cannot be snapped (error_code 171,
+      # "No suitable edges near location"). That is the caller's data being
+      # unmatchable, not Atlas's upstream misbehaving — 502 would send the
+      # operator hunting a healthy service.
+      respond(bypass, 400, ~s({"error_code":171,"error":"No suitable edges near location"}))
+
+      assert {:error, :invalid, message, details} = MapMatch.match(shape: @shape, mode: "auto")
+
+      assert message =~ "could not be matched"
+      assert details.param == "shape"
+    end
+
+    test "a 500 stays a BadResponse", %{bypass: bypass} do
+      respond(bypass, 500, "boom")
+
+      assert {:error, %Client.BadResponse{status: 500}} =
+               MapMatch.match(shape: @shape, mode: "auto")
+    end
+
+    test "a dead upstream stays Unavailable", %{bypass: bypass} do
+      Bypass.down(bypass)
+
+      assert {:error, %Client.Unavailable{}} = MapMatch.match(shape: @shape, mode: "auto")
+    end
+  end
+end

--- a/app-phoenix/test/atlas/maps/upstream/valhalla_test.exs
+++ b/app-phoenix/test/atlas/maps/upstream/valhalla_test.exs
@@ -37,4 +37,123 @@ defmodule Atlas.Maps.Upstream.ValhallaTest do
       Valhalla.route(req, from: %{lat: 0, lon: 0}, to: %{lat: 1, lon: 1}, mode: "submarine")
     end
   end
+
+  describe "trace_route/2" do
+    test "POSTs the shape, costing and shape_match to /trace_route", %{bypass: bypass, req: req} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        json = Jason.decode!(body)
+
+        assert json["costing"] == "auto"
+        assert json["shape_match"] == "map_snap"
+        assert [%{"lat" => 52.5, "lon" => 13.4}, %{"lat" => 52.6, "lon" => 13.5}] = json["shape"]
+        assert get_in(json, ["directions_options", "units"]) == "kilometers"
+
+        Plug.Conn.resp(conn, 200, ~s({"trip":{"summary":{"length":1.0}}}))
+      end)
+
+      assert {:ok, %{"trip" => _}} =
+               Valhalla.trace_route(req,
+                 shape: [%{lat: 52.5, lon: 13.4}, %{lat: 52.6, lon: 13.5}],
+                 mode: "auto"
+               )
+    end
+
+    test "carries per-point time and accuracy when present", %{bypass: bypass, req: req} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        json = Jason.decode!(body)
+
+        assert [first, second] = json["shape"]
+        assert first["time"] == 1_714_032_000
+        assert first["accuracy"] == 8.0
+        # Points without the optional keys must not carry nulls: Valhalla
+        # rejects a null `time` on an otherwise valid trace.
+        refute Map.has_key?(second, "time")
+        refute Map.has_key?(second, "accuracy")
+
+        Plug.Conn.resp(conn, 200, "{}")
+      end)
+
+      Valhalla.trace_route(req,
+        shape: [
+          %{lat: 52.5, lon: 13.4, time: 1_714_032_000, accuracy: 8.0},
+          # Explicit nils, because that is what the controller emits for a
+          # point that carried neither field. An omitted key would be dropped
+          # by Map.take/2 anyway and would not exercise the rejection at all.
+          %{lat: 52.6, lon: 13.5, time: nil, accuracy: nil}
+        ],
+        mode: "auto"
+      )
+    end
+
+    test "sends only the trace_options that were supplied", %{bypass: bypass, req: req} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        json = Jason.decode!(body)
+
+        assert json["trace_options"] == %{"search_radius" => 35, "gps_accuracy" => 5}
+
+        Plug.Conn.resp(conn, 200, "{}")
+      end)
+
+      Valhalla.trace_route(req,
+        shape: [%{lat: 52.5, lon: 13.4}, %{lat: 52.6, lon: 13.5}],
+        mode: "auto",
+        trace_options: %{search_radius: 35, gps_accuracy: 5}
+      )
+    end
+
+    test "omits trace_options entirely when none were supplied", %{bypass: bypass, req: req} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        refute Map.has_key?(Jason.decode!(body), "trace_options")
+        Plug.Conn.resp(conn, 200, "{}")
+      end)
+
+      Valhalla.trace_route(req, shape: [%{lat: 52.5, lon: 13.4}, %{lat: 52.6, lon: 13.5}], mode: "auto")
+    end
+
+    test "honours an explicit shape_match", %{bypass: bypass, req: req} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert Jason.decode!(body)["shape_match"] == "edge_walk"
+        Plug.Conn.resp(conn, 200, "{}")
+      end)
+
+      Valhalla.trace_route(req,
+        shape: [%{lat: 52.5, lon: 13.4}, %{lat: 52.6, lon: 13.5}],
+        mode: "auto",
+        shape_match: "edge_walk"
+      )
+    end
+
+    test "raises on invalid mode", %{req: req} do
+      assert_raise ArgumentError, ~r/invalid mode/, fn ->
+        Valhalla.trace_route(req, shape: [%{lat: 0, lon: 0}], mode: "submarine")
+      end
+    end
+
+    test "raises on invalid shape_match", %{req: req} do
+      assert_raise ArgumentError, ~r/invalid shape_match/, fn ->
+        Valhalla.trace_route(req, shape: [%{lat: 0, lon: 0}], mode: "auto", shape_match: "vibes")
+      end
+    end
+  end
+
+  describe "match_default/0" do
+    test "allows a longer receive timeout than point-to-point routing" do
+      # A 5000-point trace takes far longer to match than an A-to-B route, so
+      # the 15s route ceiling would abort perfectly healthy matches.
+      assert Valhalla.match_default().options[:receive_timeout] >
+               Valhalla.default().options[:receive_timeout]
+    end
+
+    test "reads VALHALLA_MATCH_TIMEOUT" do
+      System.put_env("VALHALLA_MATCH_TIMEOUT", "90000")
+      on_exit(fn -> System.delete_env("VALHALLA_MATCH_TIMEOUT") end)
+
+      assert Valhalla.match_default().options[:receive_timeout] == 90_000
+    end
+  end
 end

--- a/app-phoenix/test/atlas_web/controllers/api/v1/map_match_controller_test.exs
+++ b/app-phoenix/test/atlas_web/controllers/api/v1/map_match_controller_test.exs
@@ -1,0 +1,234 @@
+defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
+  use AtlasWeb.ConnCase, async: false
+
+  alias Atlas.Maps.MapMatch
+
+  # Decodes to [{52.5, 13.4}, {52.51, 13.41}] at precision 6.
+  @leg_a "_ajccB_{zpX_pR_pR"
+
+  @shape [
+    %{lat: 52.5, lon: 13.4, time: 1_714_032_000, accuracy: 8},
+    %{lat: 52.51, lon: 13.41, time: 1_714_032_030, accuracy: 6},
+    %{lat: 52.52, lon: 13.42, time: 1_714_032_060}
+  ]
+
+  setup do
+    bypass = Bypass.open()
+    System.put_env("VALHALLA_URL", "http://localhost:#{bypass.port}")
+    on_exit(fn -> System.delete_env("VALHALLA_URL") end)
+    {:ok, bypass: bypass}
+  end
+
+  defp submit(conn, body) do
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> post(~p"/api/v1/map-match", Jason.encode!(body))
+  end
+
+  defp stub_trip(bypass, legs \\ ~s([{"shape":"#{@leg_a}"}])) do
+    Bypass.expect_once(bypass, "POST", "/trace_route", fn conn ->
+      Plug.Conn.resp(conn, 200, ~s({"trip":{"summary":{"length":2.5},"legs":#{legs}}}))
+    end)
+  end
+
+  describe "success" do
+    test "returns the matched legs and echoes the request settings", %{
+      conn: conn,
+      bypass: bypass
+    } do
+      stub_trip(bypass)
+
+      resp = conn |> submit(%{shape: @shape, mode: "auto"}) |> json_response(200)
+
+      assert resp["data"]["summary"]["length"] == 2.5
+      assert [%{"shape" => @leg_a}] = resp["data"]["legs"]
+      assert resp["data"]["shape_format"] == "valhalla_encoded_polyline6"
+
+      assert resp["meta"]["mode"] == "auto"
+      assert resp["meta"]["shape_match"] == "map_snap"
+      assert resp["meta"]["points"] == 3
+      assert resp["meta"]["max_points"] == MapMatch.max_points()
+    end
+
+    test "format=geojson returns a decoded LineString", %{conn: conn, bypass: bypass} do
+      stub_trip(bypass)
+
+      resp =
+        conn |> submit(%{shape: @shape, mode: "auto", format: "geojson"}) |> json_response(200)
+
+      assert resp["data"]["shape_format"] == "geojson"
+
+      assert resp["data"]["geometry"] == %{
+               "type" => "LineString",
+               "coordinates" => [[13.4, 52.5], [13.41, 52.51]]
+             }
+    end
+
+    test "forwards per-point time and accuracy to Valhalla", %{conn: conn, bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+        {:ok, body, c} = Plug.Conn.read_body(c)
+        [first, _, third] = Jason.decode!(body)["shape"]
+
+        assert first["time"] == 1_714_032_000
+        assert first["accuracy"] == 8
+        refute Map.has_key?(third, "accuracy")
+
+        Plug.Conn.resp(c, 200, ~s({"trip":{"legs":[]}}))
+      end)
+
+      assert conn |> submit(%{shape: @shape}) |> json_response(200)
+    end
+
+    test "forwards trace_options", %{conn: conn, bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+        {:ok, body, c} = Plug.Conn.read_body(c)
+
+        assert Jason.decode!(body)["trace_options"] == %{
+                 "search_radius" => 35,
+                 "gps_accuracy" => 5,
+                 "breakage_distance" => 2000
+               }
+
+        Plug.Conn.resp(c, 200, ~s({"trip":{"legs":[]}}))
+      end)
+
+      body = %{
+        shape: @shape,
+        search_radius: 35,
+        gps_accuracy: 5,
+        breakage_distance: 2000
+      }
+
+      assert conn |> submit(body) |> json_response(200)
+    end
+
+    test "defaults the mode to auto", %{conn: conn, bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+        {:ok, body, c} = Plug.Conn.read_body(c)
+        assert Jason.decode!(body)["costing"] == "auto"
+        Plug.Conn.resp(c, 200, ~s({"trip":{"legs":[]}}))
+      end)
+
+      assert conn |> submit(%{shape: @shape}) |> json_response(200)
+    end
+  end
+
+  describe "request validation" do
+    test "400 when shape is absent", %{conn: conn} do
+      resp = conn |> submit(%{mode: "auto"}) |> json_response(400)
+
+      assert resp["error"]["code"] == "MISSING_PARAM"
+      assert resp["error"]["details"]["param"] == "shape"
+    end
+
+    test "400 when shape is not a list", %{conn: conn} do
+      resp = conn |> submit(%{shape: "52.5,13.4"}) |> json_response(400)
+      assert resp["error"]["code"] == "MISSING_PARAM"
+    end
+
+    test "422 when the trace has a single point", %{conn: conn} do
+      resp = conn |> submit(%{shape: [%{lat: 52.5, lon: 13.4}]}) |> json_response(422)
+
+      assert resp["error"]["code"] == "VALIDATION_ERROR"
+      assert resp["error"]["message"] =~ "at least 2"
+    end
+
+    test "422 naming the offending index when a point is unparseable", %{conn: conn} do
+      shape = [%{lat: 52.5, lon: 13.4}, %{lat: "nope", lon: 13.41}]
+
+      resp = conn |> submit(%{shape: shape}) |> json_response(422)
+
+      assert resp["error"]["code"] == "VALIDATION_ERROR"
+      assert resp["error"]["details"]["index"] == 1
+    end
+
+    test "422 when a point is missing lon entirely", %{conn: conn} do
+      resp =
+        conn
+        |> submit(%{shape: [%{lat: 52.5, lon: 13.4}, %{lat: 52.51}]})
+        |> json_response(422)
+
+      assert resp["error"]["details"]["index"] == 1
+    end
+
+    test "422 on an unsupported mode", %{conn: conn} do
+      resp = conn |> submit(%{shape: @shape, mode: "rail"}) |> json_response(422)
+
+      assert resp["error"]["code"] == "VALIDATION_ERROR"
+      assert resp["error"]["message"] =~ "mode"
+    end
+
+    test "422 on an unsupported shape_match", %{conn: conn} do
+      resp = conn |> submit(%{shape: @shape, shape_match: "vibes"}) |> json_response(422)
+
+      assert resp["error"]["message"] =~ "shape_match"
+    end
+
+    test "422 on an unsupported format", %{conn: conn} do
+      resp = conn |> submit(%{shape: @shape, format: "wkt"}) |> json_response(422)
+
+      assert resp["error"]["message"] =~ "format"
+    end
+
+    test "422 when the trace exceeds the point cap", %{conn: conn} do
+      System.put_env("MAP_MATCH_MAX_POINTS", "2")
+      on_exit(fn -> System.delete_env("MAP_MATCH_MAX_POINTS") end)
+
+      resp = conn |> submit(%{shape: @shape}) |> json_response(422)
+
+      assert resp["error"]["code"] == "VALIDATION_ERROR"
+      assert resp["error"]["details"]["max"] == 2
+    end
+
+    test "an unparseable point is rejected before Valhalla is called", %{
+      conn: conn,
+      bypass: bypass
+    } do
+      Bypass.stub(bypass, "POST", "/trace_route", fn c ->
+        flunk("upstream must not be called for a malformed trace")
+        Plug.Conn.resp(c, 200, "{}")
+      end)
+
+      conn
+      |> submit(%{shape: [%{lat: 52.5, lon: 13.4}, %{lat: nil, lon: 13.41}]})
+      |> response(422)
+    end
+  end
+
+  describe "upstream failures" do
+    test "422 rather than 502 when the trace cannot be snapped", %{conn: conn, bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+        Plug.Conn.resp(c, 400, ~s({"error_code":171,"error":"No suitable edges near location"}))
+      end)
+
+      resp = conn |> submit(%{shape: @shape}) |> json_response(422)
+
+      assert resp["error"]["code"] == "VALIDATION_ERROR"
+      assert resp["error"]["message"] =~ "could not be matched"
+    end
+
+    test "502 when Valhalla errors", %{conn: conn, bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+        Plug.Conn.resp(c, 500, "boom")
+      end)
+
+      resp = conn |> submit(%{shape: @shape}) |> json_response(502)
+      assert resp["error"]["code"] == "UPSTREAM_ERROR"
+    end
+
+    test "503 when Valhalla is down", %{conn: conn, bypass: bypass} do
+      Bypass.down(bypass)
+
+      resp = conn |> submit(%{shape: @shape}) |> json_response(503)
+      assert resp["error"]["code"] == "UPSTREAM_UNAVAILABLE"
+    end
+  end
+
+  describe "openapi" do
+    test "the endpoint is described in the published spec", %{conn: conn} do
+      spec = conn |> get(~p"/api/v1/openapi.json") |> json_response(200)
+
+      assert get_in(spec, ["paths", "/api/v1/map-match", "post", "summary"]) =~ "atch"
+    end
+  end
+end


### PR DESCRIPTION
Snaps a recorded GPS trace onto the road network via Valhalla's Meili matcher. The inverse of `/api/v1/route`: routing invents a path between two points, matching takes a path you already walked and decides which edges you were on.

A POST rather than a GET like `/route` — a trace is thousands of points, past what a query string can carry.

```json
POST /api/v1/map-match
{
  "shape": [{"lat": 52.5, "lon": 13.4, "time": 1714032000, "accuracy": 8}, ...],
  "mode": "auto",
  "shape_match": "map_snap",
  "format": "geojson",
  "search_radius": 35,
  "gps_accuracy": 5,
  "breakage_distance": 2000
}
```

`time` and `accuracy` are optional but materially improve the match — Meili weights candidate edges by GPS noise and elapsed time.

## Decisions worth reviewing

**`format=geojson` decodes server-side.** Returns one `LineString` instead of Valhalla's encoded polyline legs, so callers need no polyline6 decoder of their own. Reuses the existing `Atlas.Geometry.Polyline`. Default stays `polyline6`, matching what `/route` already returns.

**A 400 from Valhalla becomes 422, not 502.** Valhalla answers 400 when no road candidate fits the trace (`error_code` 171, "No suitable edges near location"). That is unmatchable input, not a sick upstream — a 502 would send the operator debugging a service that is behaving correctly.

**Matching gets its own timeout.** `VALHALLA_MATCH_TIMEOUT` (default 60s) separate from the 15s routing ceiling, which would abort perfectly healthy matches of a full-day trace. Paired with a 10000-point cap (`MAP_MATCH_MAX_POINTS`) — matching is superlinear in point count and holds a Valhalla worker for the whole request, so an unbounded trace is a denial-of-service on a shared instance.

## Limits

Costings stay `auto | bicycle | pedestrian`. Valhalla has no rail costing, so this does nothing for train-shaped gaps.

Not yet exercised against a real Valhalla with real tiles — #24 (Valhalla crash-loops "Too many open files" on multi-core hosts) is still open, so there is no reliable instance to point it at.

## Verification

| Check | Result |
| --- | --- |
| `mix compile --warnings-as-errors` | clean |
| `mix credo --strict` | 2W / 10R / 61Rd / 51D vs 2/10/62/51 on `main` — readability drops one (new moduledoc), nothing regressed |
| `mix test` | 431 tests, 0 failures (394 before this branch) |

Built test-first. Every fix was then mutation-tested by reverting it and confirming a test fails — seven reverts, all discriminate. One test was found vacuous that way and fixed: it asserted the nil-rejection in `shape_point/1` using a point that *omitted* `:time`, but `Map.take/2` never lifts an absent key, so the rejection was a no-op and could have been deleted with everything green. The controller emits an explicit `time: nil`, which is what the test now sends.

Also driven over real HTTP against a running endpoint rather than mocks alone:

- 503 with no Valhalla, 400 on missing `shape`, 422 on a single point, 422 naming `shape[1]` for a malformed point, 422 on `mode=rail`
- 200 happy path — upstream log confirms `/trace_route`, `costing=auto`, `shape_match=map_snap`, and `trace_options` forwarded
- `format=geojson` returned 3 coordinates from 2 legs × 2 points, deduplicating the vertex Valhalla repeats at each leg boundary
- a 10000-point trace (728 KB) returns 200, comfortably inside the 8 MB `Plug.Parsers` default; 10001 points returns 422 without reaching the upstream
