### PR TITLE
fix(map-match): relay Valhalla's rejection reason, stop 500ing on bad coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 ## [Unreleased]
 
 ### Fixed
+- Map matching reports Valhalla's own reason for rejecting a trace instead of always claiming it was unmatchable — a trace longer than Valhalla's 200 km `max_distance`, or over `max_shape`, previously came back as "outside the loaded region, or too sparse or too noisy". Upstream error bodies are now preserved on every non-2xx response, and the `error_code` is returned in the error details.
+- Map matching answers 422 instead of 500 when a coordinate is a non-numeric JSON value (`true`, an object, an array), and rejects locale-style decimals like `"52,5"` rather than silently truncating them to `52.0` — a ~55 km relocation.
+- `MAP_MATCH_MAX_POINTS` and `VALHALLA_MATCH_TIMEOUT` set in `.env` now reach the app; the compose files pass an explicit environment allowlist, so they were silently dropped. A malformed value in any `*_TIMEOUT`-style knob falls back to the default with a warning instead of raising on every request that reads it.
 - The Protomaps daily-planet basemap targets the previous day’s build, which is already published, instead of a build that may not exist yet (#2)
 - Transit planning now uses OpenTripPlanner's GraphQL API instead of the removed legacy REST endpoint (#25).
 - Region apply no longer stalls or silently serves stale POI data: the PBF→bz2 convert is no longer bounded by a 30-minute wall-clock timeout (a genuinely hung osmium is now caught by a stall watchdog instead), orphaned `.partial` files are swept from `osm/`, `osm/sources/` and `gtfs/`, and a failed conversion fails the apply loudly instead of leaving overpass on a weeks-old snapshot (#34, #28). The convert now runs after OTP staging, so a broken overpass source no longer withholds fresh data from valhalla and OTP.

--- a/app-phoenix/lib/atlas/maps/map_match.ex
+++ b/app-phoenix/lib/atlas/maps/map_match.ex
@@ -24,6 +24,10 @@ defmodule Atlas.Maps.MapMatch do
   @max_points 10_000
   @polyline_precision 6
 
+  # Only used when Valhalla's own explanation is missing or unreadable.
+  @generic_rejection "the trace could not be matched to the road network — it may lie " <>
+                       "outside the loaded region, or the points may be too sparse or too noisy"
+
   @doc """
   Upper bound on trace length, overridable with `MAP_MATCH_MAX_POINTS`.
 
@@ -79,16 +83,17 @@ defmodule Atlas.Maps.MapMatch do
     |> handle_response()
   end
 
-  # Valhalla answers 400 when no road network candidate fits the trace
-  # (error_code 171, "No suitable edges near location"). That is unmatchable
-  # input, not a sick upstream — surfacing it as 502 sends the operator
-  # debugging a service that is behaving correctly.
+  # Every Valhalla 400 is the caller's input being unusable, so 422 is right
+  # across the board — 502 would send the operator debugging a service that is
+  # behaving correctly. But the REASON varies: unmatchable geometry
+  # (error_code 171), a trace longer than `max_distance` (200 km by default —
+  # one day of driving), more points than `max_shape`, an out-of-range trace
+  # option. Relay Valhalla's own message instead of asserting one of them.
   defp handle_response({:ok, body}), do: {:ok, body}
 
-  defp handle_response({:error, %Client.BadResponse{status: 400}}) do
-    {:error, :invalid,
-     "the trace could not be matched to the road network — it may lie outside " <>
-       "the loaded region, or the points may be too sparse or too noisy", %{param: "shape"}}
+  defp handle_response({:error, %Client.BadResponse{status: 400, body: body}}) do
+    Logger.warning("valhalla rejected the trace: #{inspect(body)}")
+    {:error, :invalid, upstream_message(body), upstream_details(body)}
   end
 
   defp handle_response({:error, %Client.Unavailable{} = error}) do
@@ -100,6 +105,14 @@ defmodule Atlas.Maps.MapMatch do
     Logger.warning("valhalla bad response: #{Exception.message(error)}")
     {:error, error}
   end
+
+  defp upstream_message(%{"error" => error}) when is_binary(error) and error != "", do: error
+  defp upstream_message(_body), do: @generic_rejection
+
+  defp upstream_details(%{"error_code" => code}) when is_integer(code),
+    do: %{param: "shape", upstream_error_code: code}
+
+  defp upstream_details(_body), do: %{param: "shape"}
 
   defp build_result(body, "geojson") do
     trip = body["trip"] || %{}

--- a/app-phoenix/lib/atlas/maps/upstream/client.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/client.ex
@@ -8,12 +8,22 @@ defmodule Atlas.Maps.Upstream.Client do
   `Unavailable` (could not connect) and `BadResponse` (connected, bad status).
   """
 
+  require Logger
+
   defmodule Unavailable do
     defexception [:message, :upstream]
   end
 
   defmodule BadResponse do
-    defexception [:message, :upstream, :status]
+    @moduledoc """
+    An upstream answered, but with a non-2xx status.
+
+    `:body` carries the decoded response so callers can surface the upstream's
+    own explanation. Valhalla, for one, returns a specific `error_code` and
+    message on 400; without the body the caller can only invent a reason.
+    """
+
+    defexception [:message, :upstream, :status, :body]
   end
 
   def build(base_url, opts \\ []) do
@@ -49,7 +59,23 @@ defmodule Atlas.Maps.Upstream.Client do
   def env_int(key, default) do
     case System.get_env(key) do
       nil -> default
-      val -> String.to_integer(val)
+      "" -> default
+      val -> parse_int(key, val, default)
+    end
+  end
+
+  # Falls back rather than raising: compose renders `${VAR:-}` as an empty
+  # string for every declared-but-unset knob, and a typo in one of them used to
+  # take down every request that read it — a 500 on the whole API because a
+  # timeout was spelled "10s".
+  defp parse_int(key, val, default) do
+    case Integer.parse(val) do
+      {int, ""} ->
+        int
+
+      _ ->
+        Logger.warning("#{key}=#{inspect(val)} is not an integer, using #{default}")
+        default
     end
   end
 
@@ -63,8 +89,13 @@ defmodule Atlas.Maps.Upstream.Client do
       {:ok, %{status: s, body: body}} when s in 200..299 ->
         {:ok, maybe_decode(body)}
 
-      {:ok, %{status: s}} ->
-        {:error, %BadResponse{message: "#{s} from #{req.options[:base_url]}#{path}", status: s}}
+      {:ok, %{status: s, body: response_body}} ->
+        {:error,
+         %BadResponse{
+           message: "#{s} from #{req.options[:base_url]}#{path}",
+           status: s,
+           body: maybe_decode(response_body)
+         }}
 
       {:error, exception} ->
         {:error, %Unavailable{message: Exception.message(exception)}}
@@ -76,8 +107,13 @@ defmodule Atlas.Maps.Upstream.Client do
       {:ok, %{status: s, body: response_body}} when s in 200..299 ->
         {:ok, maybe_decode(response_body)}
 
-      {:ok, %{status: s}} ->
-        {:error, %BadResponse{message: "#{s} from #{req.options[:base_url]}#{path}", status: s}}
+      {:ok, %{status: s, body: response_body}} ->
+        {:error,
+         %BadResponse{
+           message: "#{s} from #{req.options[:base_url]}#{path}",
+           status: s,
+           body: maybe_decode(response_body)
+         }}
 
       {:error, exception} ->
         {:error, %Unavailable{message: Exception.message(exception)}}
@@ -89,8 +125,13 @@ defmodule Atlas.Maps.Upstream.Client do
       {:ok, %{status: s, body: response_body}} when s in 200..299 ->
         {:ok, maybe_decode(response_body)}
 
-      {:ok, %{status: s}} ->
-        {:error, %BadResponse{message: "#{s} from #{req.options[:base_url]}#{path}", status: s}}
+      {:ok, %{status: s, body: response_body}} ->
+        {:error,
+         %BadResponse{
+           message: "#{s} from #{req.options[:base_url]}#{path}",
+           status: s,
+           body: maybe_decode(response_body)
+         }}
 
       {:error, exception} ->
         {:error, %Unavailable{message: Exception.message(exception)}}

--- a/app-phoenix/lib/atlas_web/controllers/api/v1/map_match_controller.ex
+++ b/app-phoenix/lib/atlas_web/controllers/api/v1/map_match_controller.ex
@@ -109,8 +109,8 @@ defmodule AtlasWeb.Api.V1.MapMatchController do
   end
 
   defp parse_point(%{"lat" => lat, "lon" => lon} = raw) do
-    case {parse_float(lat), parse_float(lon)} do
-      {lat_f, lon_f} when is_number(lat_f) and is_number(lon_f) ->
+    case {coordinate(lat), coordinate(lon)} do
+      {lat_f, lon_f} when is_float(lat_f) and is_float(lon_f) ->
         {:ok,
          %{
            lat: lat_f,
@@ -125,6 +125,22 @@ defmodule AtlasWeb.Api.V1.MapMatchController do
   end
 
   defp parse_point(_raw), do: :error
+
+  # Not `BaseController.parse_float/1`: it has no catch-all clause, so a JSON
+  # `true` or `{}` raised FunctionClauseError and the client got a 500 for what
+  # is plainly bad input. It is also lenient — `Float.parse("52,5")` yields
+  # 52.0 and the point silently moves ~55 km — so trailing characters are
+  # rejected here rather than dropped.
+  defp coordinate(value) when is_number(value), do: value * 1.0
+
+  defp coordinate(value) when is_binary(value) do
+    case Float.parse(value) do
+      {float, ""} -> float
+      _ -> nil
+    end
+  end
+
+  defp coordinate(_value), do: nil
 
   defp trace_options(params) do
     Map.new(@trace_option_params, fn key ->

--- a/app-phoenix/test/atlas/maps/map_match_test.exs
+++ b/app-phoenix/test/atlas/maps/map_match_test.exs
@@ -108,8 +108,38 @@ defmodule Atlas.Maps.MapMatchTest do
 
       assert {:error, :invalid, message, details} = MapMatch.match(shape: @shape, mode: "auto")
 
+      assert message =~ "No suitable edges near location"
+      assert details.param == "shape"
+      assert details.upstream_error_code == 171
+    end
+
+    test "a 400 for a reason other than unmatchability says so", %{bypass: bypass} do
+      # 400 is not only "cannot be snapped". Valhalla's trace limits default to
+      # max_distance 200 km — one day of driving — and exceeding that, or
+      # max_shape, or an out-of-range trace option, all return 400 too.
+      # Reporting every one of them as "outside the loaded region, or too
+      # sparse or too noisy" sends the operator to fix the wrong thing.
+      respond(
+        bypass,
+        400,
+        ~s({"error_code":154,"error":"Path distance exceeds the max distance limit"})
+      )
+
+      assert {:error, :invalid, message, details} = MapMatch.match(shape: @shape, mode: "auto")
+
+      assert message =~ "max distance limit"
+      refute message =~ "too sparse"
+      assert details.upstream_error_code == 154
+    end
+
+    test "a 400 with an unreadable body falls back to a generic explanation", %{bypass: bypass} do
+      respond(bypass, 400, "<html>gateway ate it</html>")
+
+      assert {:error, :invalid, message, details} = MapMatch.match(shape: @shape, mode: "auto")
+
       assert message =~ "could not be matched"
       assert details.param == "shape"
+      refute Map.has_key?(details, :upstream_error_code)
     end
 
     test "a 500 stays a BadResponse", %{bypass: bypass} do

--- a/app-phoenix/test/atlas/maps/upstream/client_test.exs
+++ b/app-phoenix/test/atlas/maps/upstream/client_test.exs
@@ -39,4 +39,67 @@ defmodule Atlas.Maps.Upstream.ClientTest do
     req = Client.build(base_url)
     Client.get(req, "/api", [{"osm_tag", "amenity:cafe"}, {"osm_tag", "tourism:hotel"}])
   end
+
+  describe "upstream error bodies" do
+    test "BadResponse carries the decoded body so callers can read the upstream reason", %{
+      bypass: bypass,
+      base_url: base_url
+    } do
+      # Without this, an upstream that explains itself in the body (Valhalla's
+      # error_code, Photon's message) is reduced to a bare status, and the
+      # caller has to invent a reason to show the user.
+      Bypass.expect_once(bypass, "POST", "/api", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(400, ~s({"error_code":154,"error":"Path distance exceeds the max distance limit"}))
+      end)
+
+      req = Client.build(base_url)
+
+      assert {:error, %BadResponse{status: 400, body: body}} = Client.post(req, "/api", %{})
+      assert body["error_code"] == 154
+      assert body["error"] =~ "max distance limit"
+    end
+
+    test "a non-JSON error body is still carried through", %{bypass: bypass, base_url: base_url} do
+      Bypass.expect_once(bypass, "GET", "/api", fn conn -> Plug.Conn.resp(conn, 502, "upstream died") end)
+
+      req = Client.build(base_url)
+
+      assert {:error, %BadResponse{status: 502, body: "upstream died"}} = Client.get(req, "/api")
+    end
+  end
+
+  describe "env_int/2" do
+    test "reads an integer, and falls back for unset or unparseable values" do
+      on_exit(fn -> System.delete_env("ATLAS_TEST_ENV_INT") end)
+
+      assert Client.env_int("ATLAS_TEST_ENV_INT", 42) == 42
+
+      System.put_env("ATLAS_TEST_ENV_INT", "7")
+      assert Client.env_int("ATLAS_TEST_ENV_INT", 42) == 7
+
+      # A typo must not 500 every request that reads the knob.
+      System.put_env("ATLAS_TEST_ENV_INT", "10k")
+      assert Client.env_int("ATLAS_TEST_ENV_INT", 42) == 42
+    end
+
+    test "an unset-but-declared knob falls back silently, a bad value warns" do
+      # compose renders `${VAR:-}` as "" for every declared-but-unset knob, so
+      # "" is the NORMAL case and must stay quiet — warning on it would log a
+      # line per request per knob. A genuine typo must still be reported, so
+      # asserting only the return value cannot tell the two apart.
+      on_exit(fn -> System.delete_env("ATLAS_TEST_ENV_INT") end)
+
+      System.put_env("ATLAS_TEST_ENV_INT", "")
+      empty_log = ExUnit.CaptureLog.capture_log(fn -> assert Client.env_int("ATLAS_TEST_ENV_INT", 42) == 42 end)
+
+      System.put_env("ATLAS_TEST_ENV_INT", "nonsense")
+      bad_log = ExUnit.CaptureLog.capture_log(fn -> assert Client.env_int("ATLAS_TEST_ENV_INT", 42) == 42 end)
+
+      assert empty_log == ""
+      assert bad_log =~ "ATLAS_TEST_ENV_INT"
+      assert bad_log =~ "not an integer"
+    end
+  end
 end

--- a/app-phoenix/test/atlas_web/controllers/api/v1/map_match_controller_test.exs
+++ b/app-phoenix/test/atlas_web/controllers/api/v1/map_match_controller_test.exs
@@ -180,6 +180,48 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
       assert resp["error"]["details"]["max"] == 2
     end
 
+    test "422 rather than 500 for a non-numeric JSON scalar", %{conn: conn} do
+      # `true` and `%{}` are valid JSON but not coordinates. These reached
+      # parse_float/1, which has clauses only for nil/binary/number, so the
+      # request died with FunctionClauseError and the client saw a 500 — an
+      # Atlas bug report for what is plainly bad input.
+      for bad <- [true, false, %{"a" => 1}, [52.5]] do
+        resp =
+          conn
+          |> submit(%{shape: [%{lat: 52.5, lon: 13.4}, %{lat: bad, lon: 13.41}]})
+          |> json_response(422)
+
+        assert resp["error"]["code"] == "VALIDATION_ERROR"
+        assert resp["error"]["details"]["index"] == 1
+      end
+    end
+
+    test "422 rather than silently truncating a comma decimal", %{conn: conn} do
+      # Float.parse("52,5") returns {52.0, ",5"} — accepting it moved the point
+      # half a degree (~55 km) with no error anywhere. A locale-confused client
+      # must be told, not quietly relocated.
+      resp =
+        conn
+        |> submit(%{shape: [%{lat: "52,5", lon: "13,4"}, %{lat: 52.51, lon: 13.41}]})
+        |> json_response(422)
+
+      assert resp["error"]["details"]["index"] == 0
+    end
+
+    test "still accepts numeric strings and integers", %{conn: conn, bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+        {:ok, body, c} = Plug.Conn.read_body(c)
+        assert [%{"lat" => 52.5, "lon" => 13.4}, %{"lat" => 53.0, "lon" => 14.0}] =
+                 Jason.decode!(body)["shape"]
+
+        Plug.Conn.resp(c, 200, ~s({"trip":{"legs":[]}}))
+      end)
+
+      assert conn
+             |> submit(%{shape: [%{lat: "52.5", lon: "13.4"}, %{lat: 53, lon: 14}]})
+             |> json_response(200)
+    end
+
     test "an unparseable point is rejected before Valhalla is called", %{
       conn: conn,
       bypass: bypass
@@ -204,7 +246,8 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
       resp = conn |> submit(%{shape: @shape}) |> json_response(422)
 
       assert resp["error"]["code"] == "VALIDATION_ERROR"
-      assert resp["error"]["message"] =~ "could not be matched"
+      assert resp["error"]["message"] =~ "No suitable edges near location"
+      assert resp["error"]["details"]["upstream_error_code"] == 171
     end
 
     test "502 when Valhalla errors", %{conn: conn, bypass: bypass} do

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -62,6 +62,11 @@ services:
       PLACEHOLDER_URL: http://placeholder:3000
       LIBPOSTAL_URL: http://libpostal:4400
       VALHALLA_URL: http://valhalla:8002
+      # Map matching knobs. Declared here so a value set in .env actually
+      # reaches the app — this service passes an explicit allowlist, not
+      # env_file, so an undeclared variable is silently dropped.
+      MAP_MATCH_MAX_POINTS: ${MAP_MATCH_MAX_POINTS:-}
+      VALHALLA_MATCH_TIMEOUT: ${VALHALLA_MATCH_TIMEOUT:-}
       OVERPASS_URL: http://overpass:80
       OTP_URL: http://otp:8080
       TILES_URL: ${TILES_URL:-}

--- a/compose.dokploy.yml
+++ b/compose.dokploy.yml
@@ -118,6 +118,11 @@ services:
       PHOTON_URL: ${PHOTON_URL:-http://photon:2322}
       # Internal names — resolve once you uncomment the services at the bottom.
       VALHALLA_URL: http://valhalla:8002
+      # Map matching knobs. Declared here so a value set in .env actually
+      # reaches the app — this service passes an explicit allowlist, not
+      # env_file, so an undeclared variable is silently dropped.
+      MAP_MATCH_MAX_POINTS: ${MAP_MATCH_MAX_POINTS:-}
+      VALHALLA_MATCH_TIMEOUT: ${VALHALLA_MATCH_TIMEOUT:-}
       OVERPASS_URL: http://overpass:80
       OTP_URL: http://otp:8080
       TILES_URL: ${TILES_URL:-}

--- a/compose.yml
+++ b/compose.yml
@@ -46,6 +46,11 @@ services:
       PLACEHOLDER_URL: http://placeholder:3000
       LIBPOSTAL_URL: http://libpostal:4400
       VALHALLA_URL: http://valhalla:8002
+      # Map matching knobs. Declared here so a value set in .env actually
+      # reaches the app — this service passes an explicit allowlist, not
+      # env_file, so an undeclared variable is silently dropped.
+      MAP_MATCH_MAX_POINTS: ${MAP_MATCH_MAX_POINTS:-}
+      VALHALLA_MATCH_TIMEOUT: ${VALHALLA_MATCH_TIMEOUT:-}
       OVERPASS_URL: http://overpass:80
       OTP_URL: http://otp:8080
       TILES_URL: ${TILES_URL:-}


### PR DESCRIPTION
Three follow-ups to #41, all found reviewing what shipped.

## Relay the upstream reason instead of inventing one

Every Valhalla 400 was reported as *"may lie outside the loaded region, or the points may be too sparse or too noisy."* But 400 also covers a trace longer than Valhalla's `max_distance` — **200 km by default, i.e. one day of driving** — plus `max_shape` and out-of-range trace options. The operator was sent to fix the wrong thing.

422 is still correct (all of these are the caller's input being unusable), so only the message changes:

```
before: {"message": "the trace could not be matched to the road network — it may lie
                     outside the loaded region, or the points may be too sparse or too noisy"}

after:  {"message": "Path distance exceeds the max distance limit",
         "details": {"param": "shape", "upstream_error_code": 154}}
```

`Client` now preserves the response body on every non-2xx (all three verbs) — previously it kept only the status, so the upstream's explanation was unreachable. The invented sentence survives as a fallback for an unreadable body.

## Answer 422, not 500, for a non-numeric coordinate

`BaseController.parse_float/1` has clauses for `nil`, binary and number only, so a JSON `true`, `{}` or `[]` in `lat`/`lon` raised `FunctionClauseError` — a 500, i.e. a crash report for plainly bad input. Sibling controllers dodge this by guarding with `is_binary` in the function head; map matching accepts richer point shapes, so it gets a local strict parser rather than a change to the shared helper.

That parser also rejects `"52,5"` instead of letting `Float.parse/1` truncate it to `52.0` and move the point **~55 km** in silence. Legitimate numeric strings and integers still work.

## Make the documented knobs actually work

`MAP_MATCH_MAX_POINTS` and `VALHALLA_MATCH_TIMEOUT` are described in `.env.example`, but no compose file declares them and the `app` service passes an explicit `environment:` allowlist rather than `env_file:` — so setting either one did nothing. Now declared in `compose.yml`, `compose.dev.yml` and `compose.dokploy.yml`.

That change alone would have made things worse: `${VAR:-}` renders as an empty string for every unset knob, and `env_int/2` fed that to `String.to_integer/1`, which **raises** — a 500 on every request that reads it, on a default install. It now falls back to the default, warning only for a genuinely malformed value and staying quiet for the empty-but-declared case that is normal.

## Verification

| Check | Result |
| --- | --- |
| `mix compile --warnings-as-errors` | clean |
| `mix credo --strict` | `found no issues` |
| `mix test` | 488 tests, 0 failures |

Each fix was mutation-tested by reverting it and confirming a test fails — five reverts, all discriminate. One was vacuous on the first pass: removing the empty-string clause from `env_int/2` broke nothing, because `parse_int` already fell back and the return value was identical either way. The clause's real purpose is silence — compose renders `""` for every declared-but-unset knob, so warning there means a log line per request per knob. Rewritten with `capture_log` to assert empty→quiet and garbage→warns; the mutation now fails.

Driven over real HTTP against a running endpoint, not mocks alone:

- a `max_distance` rejection surfaces `"Path distance exceeds the max distance limit"` with `upstream_error_code: 154`
- `{"lat": true}` and `{"lat": {…}}` return 422 (both were 500)
- `"52,5"` is rejected, naming index 0
- `"52.5"` and `53` still reach the upstream
- `docker compose config` renders `MAP_MATCH_MAX_POINTS: "2500"` when set and `""` when unset

## Not addressed

From the same review, left open: no rate limiting on what is now the heaviest unauthenticated endpoint (needs a product decision), a match exceeding the timeout rendering as 503 rather than 504, and the point cap being checked after every point is parsed.
