### PR TITLE
ci: run the deployment-config assertions

### DIFF
--- a/.github/workflows/test-config.yml
+++ b/.github/workflows/test-config.yml
@@ -1,0 +1,37 @@
+name: test-config
+
+# Guards the deployment config the app cannot check for itself: the reverse
+# proxy headers Phoenix relies on, and the compose defaults that keep the
+# sidecars survivable. These assertions live in test/deployment_config.test.mjs
+# and had no runner at all — every regression they were written to catch could
+# land unnoticed.
+#
+# Separate from test-phoenix.yml on purpose. That workflow scopes itself to
+# `app-phoenix/**` and runs every step inside that directory, so it neither
+# triggers on a Caddyfile or compose change nor can reach a root-level test.
+on:
+  push:
+    paths:
+      - "Caddyfile"
+      - "compose*.yml"
+      - "test/*.test.mjs"
+      - ".github/workflows/test-config.yml"
+  pull_request:
+    paths:
+      - "Caddyfile"
+      - "compose*.yml"
+      - "test/*.test.mjs"
+      - ".github/workflows/test-config.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      # The glob rather than `node --test test/`: the directory form also picks
+      # up test/scripts/, which holds a shell test, and fails before running
+      # anything.
+      - run: node --test test/*.test.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - **`ghcr.io/dawarich-app/atlas/app:latest` now means "newest stable release", not "tip of `main`".** Images are cut from published GitHub releases; pushing to `main` no longer publishes one. Pin a version tag if you were relying on `latest` tracking every merge — and note that a fresh `docker compose pull` will now hold at the last release rather than moving with development.
 - Releases are tagged and published automatically from this file: when the top heading is a version with a date (rather than `Unreleased`), CI tags it, creates the GitHub release, and builds the image. Per-commit builds continue on the OneDev registry for testing.
 - `mix credo --strict` is clean and enforced in CI, with the project's ruleset checked in at `app-phoenix/.credo.exs`. It previously failed on `main` and ran ahead of the test step, so the test suite had never actually executed for a pull request.
+- The deployment-config assertions in `test/deployment_config.test.mjs` now run in CI, on a workflow that triggers when `Caddyfile` or a `compose*.yml` changes. They had no runner, so the reverse-proxy and sidecar defaults they guard could regress silently.
 
 ## [0.3.0] - 2026-06-10
 


### PR DESCRIPTION
`test/deployment_config.test.mjs` asserts the things the app cannot check for itself:

- the `X-Forwarded-Proto` header Phoenix needs behind a TLS terminator (#20, #29)
- Valhalla's worker cap and `nofile` limit (#24, #31)
- Overpass diff updates staying opt-in (#27, #30)
- Dokploy's Overpass staying off by default (#21, #32)

**Nothing ran it.** No workflow referenced the file, and neither did `.onedev-buildspec.yml`. Every regression it exists to catch could land unnoticed — awkward, given each assertion corresponds to a bug that was already fixed once.

## Why a separate workflow rather than a step in `test-phoenix.yml`

Two reasons, the second one load-bearing:

1. `test-phoenix` runs every step with `defaults.run.working-directory: app-phoenix`, so a root-level test is out of reach without a per-step override.
2. **Its paths filter is `app-phoenix/**`.** The guarded files are all at the repo root, so editing `compose.yml` or the `Caddyfile` triggers that workflow *not at all*. Adding the step there would have looked wired up while still never running on the changes that matter — worse than leaving it orphaned, because it would read as covered.

So `test-config.yml` triggers on `Caddyfile`, `compose*.yml`, `test/*.test.mjs`, and itself.

## Two details

- The command is `node --test test/*.test.mjs`, **not** `node --test test/`. The directory form descends into `test/scripts/` — which holds a shell test — and fails before running anything. Run correctly, all four pass.
- `actions/setup-node@v4` pinned to Node 22 rather than relying on whatever `ubuntu-latest` currently ships, matching how `setup-beam` is pinned.

## Verification

Every assertion was checked by breaking the config it guards and confirming the run goes red:

| Mutation | Result |
| --- | --- |
| `server_threads` cap removed | FAIL ✓ |
| `X-Forwarded-Proto` dropped from `Caddyfile` | FAIL ✓ |
| Dokploy `/overpass` proxy uncommented | FAIL ✓ |
| top-level `overpass:` service re-added | FAIL ✓ |
| restored | 4/4 pass, exit 0 ✓ |

This PR touches `.github/workflows/test-config.yml`, which is in the new workflow's own paths filter — so the check below is the workflow verifying itself.
