### PR TITLE
ci: redeploy website when Swagger changes

### DIFF
--- a/.github/workflows/redeploy-atlas-website.yml
+++ b/.github/workflows/redeploy-atlas-website.yml
@@ -1,0 +1,19 @@
+name: Redeploy Atlas website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - app/swagger/**
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  redeploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cloudflare production build
+        env:
+          DEPLOY_HOOK: ${{ secrets.ATLAS_WEBSITE_DEPLOY_HOOK }}
+        run: curl --fail --silent --show-error --request POST "$DEPLOY_HOOK"


### PR DESCRIPTION
## Summary
- Add a Cloudflare Deploy Hook for the Atlas website production branch.
- Trigger it only after files under app/swagger change on main.

## Verification
- Ruby YAML parser accepted the workflow.
- git diff --check passed.

The Deploy Hook URL is stored only in the ATLAS_WEBSITE_DEPLOY_HOOK GitHub Actions secret.