### PR TITLE
feat(map-match)!: preserve complete trace results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Dawarich Atlas are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Map matching responses include a correlation result for every input point, distance-quality statistics, and an optional `include_directions=true` expansion with maneuvers and alternate routes.
+
+### Changed
+- Map matching now uses Valhalla trace attributes as its canonical result, preserves every matched segment across trace discontinuities, returns `MultiLineString` GeoJSON for segmented traces, and emits one polyline6 leg per segment.
+
 ## [0.5.1] - 2026-09-09
 
 ### Added

--- a/app-phoenix/lib/atlas/geometry/polyline.ex
+++ b/app-phoenix/lib/atlas/geometry/polyline.ex
@@ -62,4 +62,42 @@ defmodule Atlas.Geometry.Polyline do
       decode_value(rest, shift + 5, new_result)
     end
   end
+
+  @doc """
+  Encode `{lat, lon}` tuples with Google encoded-polyline encoding.
+
+  Precision 6 is used when Atlas splits a Valhalla map match into multiple
+  independently drawable segments.
+  """
+  @spec encode([{number(), number()}], pos_integer()) :: String.t()
+  def encode(points, precision \\ 5) when is_list(points) and is_integer(precision) do
+    factor = :math.pow(10, precision)
+
+    {encoded, _lat, _lon} =
+      Enum.reduce(points, {[], 0, 0}, fn {lat, lon}, {acc, previous_lat, previous_lon} ->
+        latitude = round(lat * factor)
+        longitude = round(lon * factor)
+
+        {[acc, encode_value(latitude - previous_lat), encode_value(longitude - previous_lon)],
+         latitude, longitude}
+      end)
+
+    IO.iodata_to_binary(encoded)
+  end
+
+  defp encode_value(delta) do
+    delta
+    |> then(fn value -> if value < 0, do: bnot(bsl(value, 1)), else: bsl(value, 1) end)
+    |> encode_chunks([])
+  end
+
+  defp encode_chunks(value, acc) when value >= 0x20 do
+    encode_chunks(bsr(value, 5), [bor(0x20, band(value, 0x1F)) + 63 | acc])
+  end
+
+  defp encode_chunks(value, acc) do
+    acc
+    |> Enum.reverse([value + 63])
+    |> List.to_string()
+  end
 end

--- a/app-phoenix/lib/atlas/maps/map_match.ex
+++ b/app-phoenix/lib/atlas/maps/map_match.ex
@@ -1,18 +1,25 @@
 defmodule Atlas.Maps.MapMatch do
   @moduledoc """
   Snap a recorded GPS trace onto the road network via Valhalla's Meili
-  matcher (`/trace_route`).
+  matcher (`/trace_attributes`).
 
   This is the inverse of `Atlas.Maps.Route`: routing invents a path between
   two points, matching takes a path you already walked and decides which edges
   you were actually on.
 
+  `/trace_attributes` is used instead of `/trace_route` because it returns a
+  correlation for every input point. Valhalla may split a noisy trace into
+  several paths; Atlas preserves those paths instead of silently returning
+  only the first one.
+
   Two output shapes, chosen with `:format`:
 
-    * `"polyline6"` (default) — Valhalla's legs verbatim, each carrying an
-      encoded `shape`. Matches what `/api/v1/route` returns.
-    * `"geojson"` — legs decoded and stitched into one `LineString`, so
-      callers need no polyline decoder of their own.
+    * `"polyline6"` (default) — one encoded `shape` per matched segment.
+    * `"geojson"` — a `LineString` for one segment or a `MultiLineString`
+      when the matcher reports discontinuities.
+
+  Set `:include_directions` to make an additional `/trace_route` request and
+  include every directions path, including Valhalla's `alternates`.
   """
 
   alias Atlas.Geometry.Polyline
@@ -51,8 +58,9 @@ defmodule Atlas.Maps.MapMatch do
     shape = opts[:shape] || []
 
     with :ok <- validate_shape(shape),
-         {:ok, body} <- request(shape, opts) do
-      {:ok, build_result(body, opts[:format])}
+         {:ok, attributes} <- request_attributes(shape, opts),
+         {:ok, directions} <- request_directions(shape, opts) do
+      {:ok, build_result(attributes, opts[:format], directions)}
     end
   end
 
@@ -73,14 +81,31 @@ defmodule Atlas.Maps.MapMatch do
     end
   end
 
-  defp request(shape, opts) do
-    Valhalla.trace_route(
+  defp request_attributes(shape, opts) do
+    Valhalla.trace_attributes(trace_request(shape, opts))
+    |> handle_response()
+  end
+
+  defp request_directions(shape, opts) do
+    if opts[:include_directions] do
+      Valhalla.trace_route(trace_request(shape, opts))
+      |> handle_response()
+      |> case do
+        {:ok, body} -> {:ok, direction_paths(body)}
+        error -> error
+      end
+    else
+      {:ok, nil}
+    end
+  end
+
+  defp trace_request(shape, opts) do
+    [
       shape: shape,
       mode: opts[:mode] || "auto",
       shape_match: opts[:shape_match],
       trace_options: opts[:trace_options]
-    )
-    |> handle_response()
+    ]
   end
 
   # Every Valhalla 400 is the caller's input being unusable, so 422 is right
@@ -114,40 +139,192 @@ defmodule Atlas.Maps.MapMatch do
 
   defp upstream_details(_body), do: %{param: "shape"}
 
-  defp build_result(body, "geojson") do
-    trip = body["trip"] || %{}
+  defp build_result(body, format, directions) do
+    segments = matched_segments(body)
 
-    %Result{
-      features: %{
-        summary: trip["summary"] || %{},
-        geometry: %{type: "LineString", coordinates: coordinates(trip["legs"] || [])},
-        shape_format: "geojson"
-      },
-      upstream_status: "ok"
+    common = %{
+      summary: aggregate_summary(segments),
+      matched_points: matched_points(body["matched_points"] || []),
+      stats: match_stats(body, segments)
+    }
+
+    features =
+      case format do
+        "geojson" -> Map.merge(common, geojson_features(segments))
+        _ -> Map.merge(common, polyline_features(segments))
+      end
+      |> maybe_put_directions(directions)
+
+    %Result{features: features, upstream_status: "ok"}
+  end
+
+  # A reset in edge elapsed time marks the start of a new discontinuous path.
+  # Valhalla serializes every path into one encoded shape, so drawing it as one
+  # LineString creates false straight lines across unmatched gaps. Split at the
+  # first shape index of every reset and keep each path independently drawable.
+  defp matched_segments(body) do
+    coordinates = Polyline.decode(body["shape"] || "", @polyline_precision)
+    edges = body["edges"] || []
+
+    case split_edges(edges) do
+      [] when coordinates == [] -> []
+      [] -> [%{coordinates: coordinates, summary: %{length: 0.0, time: 0.0}}]
+      groups -> Enum.map(groups, &segment(&1, coordinates))
+    end
+    |> Enum.reject(&(length(&1.coordinates) < 2))
+  end
+
+  defp split_edges(edges) do
+    {groups, current, _elapsed} =
+      Enum.reduce(edges, {[], [], nil}, &split_edge/2)
+
+    groups = if current == [], do: groups, else: [Enum.reverse(current) | groups]
+    Enum.reverse(groups)
+  end
+
+  defp split_edge(edge, {groups, current, previous_elapsed}) do
+    elapsed = get_in(edge, ["end_node", "elapsed_time"])
+
+    if elapsed_reset?(current, previous_elapsed, elapsed) do
+      {[Enum.reverse(current) | groups], [edge], elapsed}
+    else
+      next_elapsed = if is_number(elapsed), do: elapsed, else: previous_elapsed
+      {groups, [edge | current], next_elapsed}
+    end
+  end
+
+  defp elapsed_reset?(current, previous, elapsed) do
+    current != [] and is_number(elapsed) and is_number(previous) and elapsed < previous
+  end
+
+  defp segment(edges, coordinates) do
+    first = List.first(edges) || %{}
+    last = List.last(edges) || %{}
+    first_index = first["begin_shape_index"] || 0
+    last_index = last["end_shape_index"] || first_index
+
+    %{
+      coordinates: Enum.slice(coordinates, first_index, last_index - first_index + 1),
+      summary: %{
+        length: edges |> Enum.reduce(0.0, &sum_edge_length/2) |> round_metric(),
+        time: last |> get_in(["end_node", "elapsed_time"]) |> then(&(&1 || 0.0)) |> round_metric()
+      }
     }
   end
 
-  defp build_result(body, _format) do
-    trip = body["trip"] || %{}
+  defp sum_edge_length(%{"length" => length}, total) when is_number(length), do: total + length
+  defp sum_edge_length(_edge, total), do: total
 
-    %Result{
-      features: %{
-        summary: trip["summary"] || %{},
-        legs: trip["legs"] || [],
-        shape_format: "valhalla_encoded_polyline6"
-      },
-      upstream_status: "ok"
+  defp aggregate_summary(segments) do
+    summary =
+      Enum.reduce(segments, %{length: 0.0, time: 0.0}, fn segment, summary ->
+        %{
+          length: summary.length + segment.summary.length,
+          time: summary.time + segment.summary.time
+        }
+      end)
+
+    %{length: round_metric(summary.length), time: round_metric(summary.time)}
+  end
+
+  defp matched_points(points) do
+    points
+    |> Enum.with_index()
+    |> Enum.map(fn {point, index} ->
+      %{
+        input_index: index,
+        lat: point["lat"],
+        lon: point["lon"],
+        type: point["type"],
+        edge_index: point["edge_index"],
+        distance_along_edge: point["distance_along_edge"],
+        distance_from_trace_point: point["distance_from_trace_point"]
+      }
+    end)
+  end
+
+  defp match_stats(body, segments) do
+    points = body["matched_points"] || []
+    frequencies = Enum.frequencies_by(points, &(&1["type"] || "unmatched"))
+
+    distances =
+      points
+      |> Enum.map(& &1["distance_from_trace_point"])
+      |> Enum.filter(&is_number/1)
+      |> Enum.sort()
+
+    %{
+      matched: Map.get(frequencies, "matched", 0),
+      interpolated: Map.get(frequencies, "interpolated", 0),
+      unmatched: Map.get(frequencies, "unmatched", 0),
+      segments: length(segments),
+      mean_distance_from_trace_point: mean(distances),
+      p95_distance_from_trace_point: percentile(distances, 0.95),
+      max_distance_from_trace_point: List.last(distances),
+      confidence_score: body["confidence_score"],
+      raw_score: body["raw_score"]
     }
   end
 
-  # Valhalla repeats the boundary vertex at the end of one leg and the start of
-  # the next, so a flat concatenation emits it twice. `Enum.dedup/1` drops only
-  # consecutive repeats, which is exactly the seam and never a genuine
-  # stationary stretch elsewhere in the trace.
-  defp coordinates(legs) do
-    legs
-    |> Enum.flat_map(&Polyline.decode(&1["shape"] || "", @polyline_precision))
-    |> Enum.dedup()
-    |> Enum.map(fn {lat, lon} -> [lon, lat] end)
+  defp mean([]), do: nil
+  defp mean(values), do: values |> Enum.sum() |> Kernel./(length(values)) |> round_metric()
+
+  defp percentile([], _percentile), do: nil
+
+  defp percentile(values, percentile) do
+    index = max(ceil(length(values) * percentile) - 1, 0)
+    Enum.at(values, index)
+  end
+
+  defp geojson_features(segments) do
+    line_strings = Enum.map(segments, &geojson_coordinates(&1.coordinates))
+
+    geometry =
+      case line_strings do
+        [coordinates] -> %{type: "LineString", coordinates: coordinates}
+        coordinates -> %{type: "MultiLineString", coordinates: coordinates}
+      end
+
+    %{
+      geometry: geometry,
+      segments:
+        Enum.map(segments, fn segment ->
+          %{
+            summary: segment.summary,
+            geometry: %{type: "LineString", coordinates: geojson_coordinates(segment.coordinates)}
+          }
+        end),
+      shape_format: "geojson"
+    }
+  end
+
+  defp polyline_features(segments) do
+    legs =
+      Enum.map(segments, fn segment ->
+        %{
+          summary: segment.summary,
+          shape: Polyline.encode(segment.coordinates, @polyline_precision)
+        }
+      end)
+
+    %{legs: legs, shape_format: "valhalla_encoded_polyline6"}
+  end
+
+  defp geojson_coordinates(coordinates),
+    do: Enum.map(coordinates, fn {lat, lon} -> [lon, lat] end)
+
+  defp round_metric(value), do: Float.round(value * 1.0, 3)
+
+  defp maybe_put_directions(features, nil), do: features
+  defp maybe_put_directions(features, paths), do: Map.put(features, :directions, %{paths: paths})
+
+  defp direction_paths(body) do
+    [body["trip"] | body["alternates"] || []]
+    |> Enum.map(fn
+      %{"trip" => trip} -> trip
+      trip -> trip
+    end)
+    |> Enum.filter(&is_map/1)
+    |> Enum.map(&Map.take(&1, ["summary", "legs"]))
   end
 end

--- a/app-phoenix/lib/atlas/maps/upstream/valhalla.ex
+++ b/app-phoenix/lib/atlas/maps/upstream/valhalla.ex
@@ -64,6 +64,25 @@ defmodule Atlas.Maps.Upstream.Valhalla do
   """
   def trace_route(req \\ nil, opts) do
     req = req || match_default()
+    body = trace_body(opts) |> Map.put(:directions_options, %{units: "kilometers"})
+
+    Client.post(req, "/trace_route", body)
+  end
+
+  @doc """
+  Correlate every recorded point with the road network.
+
+  Unlike `/trace_route`, `/trace_attributes` returns one `matched_points`
+  entry for every input point and one encoded shape spanning every matched
+  section. Atlas uses this as the canonical map-matching response; directions
+  remain an optional, separate `/trace_route` request.
+  """
+  def trace_attributes(req \\ nil, opts) do
+    req = req || match_default()
+    Client.post(req, "/trace_attributes", trace_body(opts))
+  end
+
+  defp trace_body(opts) do
     mode = opts[:mode] || "auto"
     shape_match = opts[:shape_match] || "map_snap"
 
@@ -73,16 +92,12 @@ defmodule Atlas.Maps.Upstream.Valhalla do
       raise(ArgumentError, "invalid shape_match #{shape_match}")
     end
 
-    body =
-      %{
-        shape: Enum.map(opts[:shape] || [], &shape_point/1),
-        costing: mode,
-        shape_match: shape_match,
-        directions_options: %{units: "kilometers"}
-      }
-      |> maybe_add_trace_options(opts[:trace_options])
-
-    Client.post(req, "/trace_route", body)
+    %{
+      shape: Enum.map(opts[:shape] || [], &shape_point/1),
+      costing: mode,
+      shape_match: shape_match
+    }
+    |> maybe_add_trace_options(opts[:trace_options])
   end
 
   # Only the keys actually present are emitted: Valhalla rejects a null `time`

--- a/app-phoenix/lib/atlas_web/controllers/api/v1/map_match_controller.ex
+++ b/app-phoenix/lib/atlas_web/controllers/api/v1/map_match_controller.ex
@@ -21,13 +21,15 @@ defmodule AtlasWeb.Api.V1.MapMatchController do
   operation(:create,
     summary: "Map-match a recorded GPS trace onto the road network",
     description: """
-    Takes the points you actually recorded and returns the road geometry you
-    were on. `shape` is an array of `{lat, lon}` objects, optionally carrying
-    `time` (epoch seconds) and `accuracy` (metres) — supplying both materially
-    improves the match.
+    Takes the points you actually recorded and returns every matched road
+    segment plus a correlation result for each input point. `shape` is an array
+    of `{lat, lon}` objects, optionally carrying `time` (epoch seconds) and
+    `accuracy` (metres) — supplying both materially improves the match.
 
-    Set `format` to `geojson` to get a decoded `LineString` instead of
-    Valhalla's encoded polyline legs.
+    Set `format` to `geojson` to get decoded `LineString` or `MultiLineString`
+    geometry instead of encoded polyline segments. Set `include_directions`
+    only when narrative directions are needed; it performs a second Valhalla
+    request and preserves every returned directions path.
     """,
     request_body:
       {"Map match request", "application/json",
@@ -35,15 +37,30 @@ defmodule AtlasWeb.Api.V1.MapMatchController do
          type: :object,
          required: [:shape],
          properties: %{
-           shape: %OpenApiSpex.Schema{type: :array, description: "Recorded points, in order"},
+           shape: %OpenApiSpex.Schema{
+             type: :array,
+             minItems: 2,
+             description: "Recorded points, in order",
+             items: %OpenApiSpex.Schema{
+               type: :object,
+               required: [:lat, :lon],
+               properties: %{
+                 lat: %OpenApiSpex.Schema{type: :number},
+                 lon: %OpenApiSpex.Schema{type: :number},
+                 time: %OpenApiSpex.Schema{type: :integer, description: "Epoch seconds"},
+                 accuracy: %OpenApiSpex.Schema{type: :number, description: "Metres"}
+               }
+             }
+           },
            mode: %OpenApiSpex.Schema{type: :string, enum: Valhalla.modes()},
            shape_match: %OpenApiSpex.Schema{type: :string, enum: Valhalla.shape_matches()},
            format: %OpenApiSpex.Schema{type: :string, enum: @formats},
+           include_directions: %OpenApiSpex.Schema{type: :boolean, default: false},
            search_radius: %OpenApiSpex.Schema{type: :number},
            gps_accuracy: %OpenApiSpex.Schema{type: :number},
            breakage_distance: %OpenApiSpex.Schema{type: :number}
          }
-       }},
+       }, required: true},
     responses: %{
       200 => response("Matched trace", "application/json", Schemas.Response),
       400 => response("Missing shape", "application/json", Schemas.Error),
@@ -59,12 +76,15 @@ defmodule AtlasWeb.Api.V1.MapMatchController do
          {:ok, shape_match} <-
            parse_enum(params["shape_match"], Valhalla.shape_matches(), "shape_match", "map_snap"),
          {:ok, format} <- parse_enum(params["format"], @formats, "format", "polyline6"),
+         {:ok, include_directions} <-
+           parse_boolean(params["include_directions"], "include_directions", false),
          {:ok, result} <-
            MapMatch.match(
              shape: shape,
              mode: mode,
              shape_match: shape_match,
              format: format,
+             include_directions: include_directions,
              trace_options: trace_options(params)
            ) do
       json(conn, %{
@@ -74,6 +94,7 @@ defmodule AtlasWeb.Api.V1.MapMatchController do
             mode: mode,
             shape_match: shape_match,
             format: format,
+            include_directions: include_directions,
             points: length(shape),
             max_points: MapMatch.max_points()
           })
@@ -173,5 +194,14 @@ defmodule AtlasWeb.Api.V1.MapMatchController do
   defp enum_error(allowed, name) do
     {:error, :invalid, "#{name} must be one of #{Enum.join(allowed, ", ")}",
      %{param: name, allowed: allowed}}
+  end
+
+  defp parse_boolean(value, _name, default) when value in [nil, ""], do: {:ok, default}
+  defp parse_boolean(value, _name, _default) when is_boolean(value), do: {:ok, value}
+  defp parse_boolean("true", _name, _default), do: {:ok, true}
+  defp parse_boolean("false", _name, _default), do: {:ok, false}
+
+  defp parse_boolean(_value, name, _default) do
+    {:error, :invalid, "#{name} must be true or false", %{param: name}}
   end
 end

--- a/app-phoenix/test/atlas/geometry/polyline_test.exs
+++ b/app-phoenix/test/atlas/geometry/polyline_test.exs
@@ -67,4 +67,22 @@ defmodule Atlas.Geometry.PolylineTest do
       assert_in_delta lon, -120.2, 0.00001
     end
   end
+
+  describe "encode/2" do
+    test "encodes the official Google example" do
+      points = [{38.5, -120.2}, {40.7, -120.95}, {43.252, -126.453}]
+
+      assert Polyline.encode(points, 5) == "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+    end
+
+    test "round-trips Valhalla precision-6 coordinates" do
+      points = [{52.5, 13.4}, {52.51, 13.41}, {52.52, 13.42}]
+
+      assert points == points |> Polyline.encode(6) |> Polyline.decode(6)
+    end
+
+    test "encodes an empty shape" do
+      assert Polyline.encode([], 6) == ""
+    end
+  end
 end

--- a/app-phoenix/test/atlas/maps/map_match_test.exs
+++ b/app-phoenix/test/atlas/maps/map_match_test.exs
@@ -1,17 +1,11 @@
 defmodule Atlas.Maps.MapMatchTest do
   use ExUnit.Case, async: false
 
+  alias Atlas.Geometry.Polyline
   alias Atlas.Maps.MapMatch
   alias Atlas.Maps.Upstream.Client
 
-  # Verified against Atlas.Geometry.Polyline.decode(_, 6):
-  #   LEG_A -> [{52.5, 13.4}, {52.51, 13.41}]
-  #   LEG_B -> [{52.51, 13.41}, {52.52, 13.42}]
-  # The legs deliberately share {52.51, 13.41} — Valhalla repeats the boundary
-  # point in each leg, and a naive concatenation would emit it twice.
   @leg_a "_ajccB_{zpX_pR_pR"
-  @leg_b "_r}ccB_lnqX_pR_pR"
-
   @shape [%{lat: 52.5, lon: 13.4}, %{lat: 52.51, lon: 13.41}, %{lat: 52.52, lon: 13.42}]
 
   setup do
@@ -21,25 +15,69 @@ defmodule Atlas.Maps.MapMatchTest do
     {:ok, bypass: bypass}
   end
 
-  defp respond(bypass, status, body) do
-    Bypass.expect_once(bypass, "POST", "/trace_route", fn conn ->
-      Plug.Conn.resp(conn, status, body)
-    end)
+  defp respond(bypass, status, body, path \\ "/trace_attributes") do
+    Bypass.expect_once(bypass, "POST", path, fn conn -> Plug.Conn.resp(conn, status, body) end)
+  end
+
+  defp attributes(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "shape" => @leg_a,
+        "edges" => [
+          %{
+            "length" => 1.25,
+            "begin_shape_index" => 0,
+            "end_shape_index" => 1,
+            "end_node" => %{"elapsed_time" => 300.0}
+          }
+        ],
+        "matched_points" => [
+          %{
+            "lat" => 52.5,
+            "lon" => 13.4,
+            "type" => "matched",
+            "edge_index" => 0,
+            "distance_along_edge" => 0.0,
+            "distance_from_trace_point" => 3.0
+          },
+          %{
+            "lat" => 52.51,
+            "lon" => 13.41,
+            "type" => "interpolated",
+            "edge_index" => 0,
+            "distance_along_edge" => 1.0,
+            "distance_from_trace_point" => 9.0
+          },
+          %{"type" => "unmatched"}
+        ],
+        "confidence_score" => 0.91,
+        "raw_score" => 12.5
+      },
+      overrides
+    )
   end
 
   describe "match/1" do
-    test "normalises the trip envelope into a Result", %{bypass: bypass} do
-      respond(bypass, 200, ~s({"trip":{"summary":{"length":2.5},"legs":[{"shape":"#{@leg_a}"}]}}))
+    test "returns matched segments and per-point quality", %{bypass: bypass} do
+      respond(bypass, 200, Jason.encode!(attributes()))
 
       assert {:ok, result} = MapMatch.match(shape: @shape, mode: "auto")
 
-      assert result.features.summary == %{"length" => 2.5}
-      assert [%{"shape" => @leg_a}] = result.features.legs
+      assert result.features.summary == %{length: 1.25, time: 300.0}
+      assert [%{shape: @leg_a, summary: %{length: 1.25}}] = result.features.legs
       assert result.features.shape_format == "valhalla_encoded_polyline6"
+      assert Enum.map(result.features.matched_points, & &1.input_index) == [0, 1, 2]
+      assert result.features.stats.matched == 1
+      assert result.features.stats.interpolated == 1
+      assert result.features.stats.unmatched == 1
+      assert result.features.stats.segments == 1
+      assert result.features.stats.mean_distance_from_trace_point == 6.0
+      assert result.features.stats.p95_distance_from_trace_point == 9.0
+      assert result.features.stats.confidence_score == 0.91
       assert result.upstream_status == "ok"
     end
 
-    test "rejects a trace with fewer than two points", %{bypass: _bypass} do
+    test "rejects a trace with fewer than two points" do
       assert {:error, :invalid, message, details} =
                MapMatch.match(shape: [%{lat: 52.5, lon: 13.4}], mode: "auto")
 
@@ -58,17 +96,15 @@ defmodule Atlas.Maps.MapMatchTest do
     test "max_points/0 is overridable via MAP_MATCH_MAX_POINTS" do
       System.put_env("MAP_MATCH_MAX_POINTS", "7")
       on_exit(fn -> System.delete_env("MAP_MATCH_MAX_POINTS") end)
-
       assert MapMatch.max_points() == 7
     end
   end
 
   describe "geojson output" do
-    test "decodes the legs into a single LineString of [lon, lat]", %{bypass: bypass} do
-      respond(bypass, 200, ~s({"trip":{"summary":{},"legs":[{"shape":"#{@leg_a}"}]}}))
+    test "returns a LineString for one matched segment", %{bypass: bypass} do
+      respond(bypass, 200, Jason.encode!(attributes()))
 
       assert {:ok, result} = MapMatch.match(shape: @shape, mode: "auto", format: "geojson")
-
       assert result.features.shape_format == "geojson"
 
       assert result.features.geometry == %{
@@ -76,49 +112,86 @@ defmodule Atlas.Maps.MapMatchTest do
                coordinates: [[13.4, 52.5], [13.41, 52.51]]
              }
 
-      # The encoded legs are redundant once decoded, and shipping both doubles
-      # the payload for the exact consumer that asked not to decode anything.
+      assert [%{geometry: %{type: "LineString"}}] = result.features.segments
       refute Map.has_key?(result.features, :legs)
     end
 
-    test "joins consecutive legs without repeating the shared boundary point", %{bypass: bypass} do
+    test "preserves discontinuous paths as a MultiLineString", %{bypass: bypass} do
+      points = Enum.map(@shape, &{&1.lat, &1.lon}) ++ [{52.6, 13.6}, {52.61, 13.61}]
+
+      edges = [
+        %{
+          "length" => 1.0,
+          "begin_shape_index" => 0,
+          "end_shape_index" => 1,
+          "end_node" => %{"elapsed_time" => 10.0}
+        },
+        %{
+          "length" => 1.0,
+          "begin_shape_index" => 1,
+          "end_shape_index" => 2,
+          "end_node" => %{"elapsed_time" => 20.0}
+        },
+        %{
+          "length" => 2.0,
+          "begin_shape_index" => 3,
+          "end_shape_index" => 4,
+          "end_node" => %{"elapsed_time" => 5.0}
+        }
+      ]
+
+      body = attributes(%{"shape" => Polyline.encode(points, 6), "edges" => edges})
+      respond(bypass, 200, Jason.encode!(body))
+
+      assert {:ok, result} = MapMatch.match(shape: @shape, format: "geojson")
+      assert result.features.summary == %{length: 4.0, time: 25.0}
+      assert result.features.stats.segments == 2
+
+      assert result.features.geometry == %{
+               type: "MultiLineString",
+               coordinates: [
+                 [[13.4, 52.5], [13.41, 52.51], [13.42, 52.52]],
+                 [[13.6, 52.6], [13.61, 52.61]]
+               ]
+             }
+    end
+  end
+
+  describe "directions" do
+    test "optionally preserves primary and alternate paths", %{bypass: bypass} do
+      respond(bypass, 200, Jason.encode!(attributes()))
+
       respond(
         bypass,
         200,
-        ~s({"trip":{"summary":{},"legs":[{"shape":"#{@leg_a}"},{"shape":"#{@leg_b}"}]}})
+        Jason.encode!(%{
+          "trip" => %{"summary" => %{"length" => 1.0}, "legs" => [%{"shape" => "a"}]},
+          "alternates" => [
+            %{"summary" => %{"length" => 2.0}, "legs" => [%{"shape" => "b"}]}
+          ]
+        }),
+        "/trace_route"
       )
 
-      assert {:ok, result} = MapMatch.match(shape: @shape, mode: "auto", format: "geojson")
+      assert {:ok, result} =
+               MapMatch.match(shape: @shape, include_directions: true, format: "geojson")
 
-      assert result.features.geometry.coordinates == [
-               [13.4, 52.5],
-               [13.41, 52.51],
-               [13.42, 52.52]
-             ]
+      assert [primary, alternate] = result.features.directions.paths
+      assert primary["summary"]["length"] == 1.0
+      assert alternate["summary"]["length"] == 2.0
     end
   end
 
   describe "upstream failures" do
-    test "a 400 becomes a validation error, not a bad gateway", %{bypass: bypass} do
-      # Valhalla answers 400 when the trace cannot be snapped (error_code 171,
-      # "No suitable edges near location"). That is the caller's data being
-      # unmatchable, not Atlas's upstream misbehaving — 502 would send the
-      # operator hunting a healthy service.
+    test "a 400 becomes a validation error", %{bypass: bypass} do
       respond(bypass, 400, ~s({"error_code":171,"error":"No suitable edges near location"}))
 
       assert {:error, :invalid, message, details} = MapMatch.match(shape: @shape, mode: "auto")
-
       assert message =~ "No suitable edges near location"
-      assert details.param == "shape"
-      assert details.upstream_error_code == 171
+      assert details == %{param: "shape", upstream_error_code: 171}
     end
 
-    test "a 400 for a reason other than unmatchability says so", %{bypass: bypass} do
-      # 400 is not only "cannot be snapped". Valhalla's trace limits default to
-      # max_distance 200 km — one day of driving — and exceeding that, or
-      # max_shape, or an out-of-range trace option, all return 400 too.
-      # Reporting every one of them as "outside the loaded region, or too
-      # sparse or too noisy" sends the operator to fix the wrong thing.
+    test "a different rejection keeps its reason", %{bypass: bypass} do
       respond(
         bypass,
         400,
@@ -126,20 +199,16 @@ defmodule Atlas.Maps.MapMatchTest do
       )
 
       assert {:error, :invalid, message, details} = MapMatch.match(shape: @shape, mode: "auto")
-
       assert message =~ "max distance limit"
-      refute message =~ "too sparse"
       assert details.upstream_error_code == 154
     end
 
-    test "a 400 with an unreadable body falls back to a generic explanation", %{bypass: bypass} do
+    test "an unreadable 400 uses the generic explanation", %{bypass: bypass} do
       respond(bypass, 400, "<html>gateway ate it</html>")
 
       assert {:error, :invalid, message, details} = MapMatch.match(shape: @shape, mode: "auto")
-
       assert message =~ "could not be matched"
-      assert details.param == "shape"
-      refute Map.has_key?(details, :upstream_error_code)
+      assert details == %{param: "shape"}
     end
 
     test "a 500 stays a BadResponse", %{bypass: bypass} do
@@ -151,7 +220,6 @@ defmodule Atlas.Maps.MapMatchTest do
 
     test "a dead upstream stays Unavailable", %{bypass: bypass} do
       Bypass.down(bypass)
-
       assert {:error, %Client.Unavailable{}} = MapMatch.match(shape: @shape, mode: "auto")
     end
   end

--- a/app-phoenix/test/atlas/maps/upstream/valhalla_test.exs
+++ b/app-phoenix/test/atlas/maps/upstream/valhalla_test.exs
@@ -157,6 +157,47 @@ defmodule Atlas.Maps.Upstream.ValhallaTest do
     end
   end
 
+  describe "trace_attributes/2" do
+    test "POSTs the trace to /trace_attributes", %{bypass: bypass, req: req} do
+      Bypass.expect_once(bypass, "POST", "/trace_attributes", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        json = Jason.decode!(body)
+
+        assert json["costing"] == "bicycle"
+        assert json["shape_match"] == "map_snap"
+
+        assert [
+                 %{"lat" => 52.5, "lon" => 13.4, "time" => 100, "accuracy" => 7},
+                 %{"lat" => 52.6, "lon" => 13.5}
+               ] = json["shape"]
+
+        assert json["trace_options"] == %{"search_radius" => 35}
+        refute Map.has_key?(json, "directions_options")
+
+        Plug.Conn.resp(conn, 200, ~s({"shape":"abc","matched_points":[]}))
+      end)
+
+      assert {:ok, %{"shape" => "abc"}} =
+               Valhalla.trace_attributes(req,
+                 shape: [
+                   %{lat: 52.5, lon: 13.4, time: 100, accuracy: 7},
+                   %{lat: 52.6, lon: 13.5}
+                 ],
+                 mode: "bicycle",
+                 trace_options: %{search_radius: 35}
+               )
+    end
+
+    test "validates shape_match", %{req: req} do
+      assert_raise ArgumentError, ~r/invalid shape_match/, fn ->
+        Valhalla.trace_attributes(req,
+          shape: [%{lat: 52.5, lon: 13.4}, %{lat: 52.6, lon: 13.5}],
+          shape_match: "vibes"
+        )
+      end
+    end
+  end
+
   describe "match_default/0" do
     test "allows a longer receive timeout than point-to-point routing" do
       # A 5000-point trace takes far longer to match than an A-to-B route, so

--- a/app-phoenix/test/atlas_web/controllers/api/v1/map_match_controller_test.exs
+++ b/app-phoenix/test/atlas_web/controllers/api/v1/map_match_controller_test.exs
@@ -25,9 +25,13 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
     |> post(~p"/api/v1/map-match", Jason.encode!(body))
   end
 
-  defp stub_trip(bypass, legs \\ ~s([{"shape":"#{@leg_a}"}])) do
-    Bypass.expect_once(bypass, "POST", "/trace_route", fn conn ->
-      Plug.Conn.resp(conn, 200, ~s({"trip":{"summary":{"length":2.5},"legs":#{legs}}}))
+  defp stub_attributes(bypass) do
+    Bypass.expect_once(bypass, "POST", "/trace_attributes", fn conn ->
+      Plug.Conn.resp(
+        conn,
+        200,
+        ~s({"shape":"#{@leg_a}","edges":[{"length":2.5,"begin_shape_index":0,"end_shape_index":1,"end_node":{"elapsed_time":300}}],"matched_points":[]})
+      )
     end)
   end
 
@@ -36,7 +40,7 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
       conn: conn,
       bypass: bypass
     } do
-      stub_trip(bypass)
+      stub_attributes(bypass)
 
       resp = conn |> submit(%{shape: @shape, mode: "auto"}) |> json_response(200)
 
@@ -46,12 +50,13 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
 
       assert resp["meta"]["mode"] == "auto"
       assert resp["meta"]["shape_match"] == "map_snap"
+      assert resp["meta"]["include_directions"] == false
       assert resp["meta"]["points"] == 3
       assert resp["meta"]["max_points"] == MapMatch.max_points()
     end
 
     test "format=geojson returns a decoded LineString", %{conn: conn, bypass: bypass} do
-      stub_trip(bypass)
+      stub_attributes(bypass)
 
       resp =
         conn |> submit(%{shape: @shape, mode: "auto", format: "geojson"}) |> json_response(200)
@@ -65,7 +70,7 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
     end
 
     test "forwards per-point time and accuracy to Valhalla", %{conn: conn, bypass: bypass} do
-      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+      Bypass.expect_once(bypass, "POST", "/trace_attributes", fn c ->
         {:ok, body, c} = Plug.Conn.read_body(c)
         [first, _, third] = Jason.decode!(body)["shape"]
 
@@ -73,14 +78,14 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
         assert first["accuracy"] == 8
         refute Map.has_key?(third, "accuracy")
 
-        Plug.Conn.resp(c, 200, ~s({"trip":{"legs":[]}}))
+        Plug.Conn.resp(c, 200, ~s({"shape":"#{@leg_a}","edges":[],"matched_points":[]}))
       end)
 
       assert conn |> submit(%{shape: @shape}) |> json_response(200)
     end
 
     test "forwards trace_options", %{conn: conn, bypass: bypass} do
-      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+      Bypass.expect_once(bypass, "POST", "/trace_attributes", fn c ->
         {:ok, body, c} = Plug.Conn.read_body(c)
 
         assert Jason.decode!(body)["trace_options"] == %{
@@ -89,7 +94,7 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
                  "breakage_distance" => 2000
                }
 
-        Plug.Conn.resp(c, 200, ~s({"trip":{"legs":[]}}))
+        Plug.Conn.resp(c, 200, ~s({"shape":"#{@leg_a}","edges":[],"matched_points":[]}))
       end)
 
       body = %{
@@ -103,13 +108,33 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
     end
 
     test "defaults the mode to auto", %{conn: conn, bypass: bypass} do
-      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+      Bypass.expect_once(bypass, "POST", "/trace_attributes", fn c ->
         {:ok, body, c} = Plug.Conn.read_body(c)
         assert Jason.decode!(body)["costing"] == "auto"
-        Plug.Conn.resp(c, 200, ~s({"trip":{"legs":[]}}))
+        Plug.Conn.resp(c, 200, ~s({"shape":"#{@leg_a}","edges":[],"matched_points":[]}))
       end)
 
       assert conn |> submit(%{shape: @shape}) |> json_response(200)
+    end
+
+    test "include_directions keeps every Valhalla directions path", %{conn: conn, bypass: bypass} do
+      stub_attributes(bypass)
+
+      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+        Plug.Conn.resp(
+          c,
+          200,
+          ~s({"trip":{"summary":{"length":1},"legs":[]},"alternates":[{"summary":{"length":2},"legs":[]}]})
+        )
+      end)
+
+      resp =
+        conn
+        |> submit(%{shape: @shape, include_directions: true})
+        |> json_response(200)
+
+      assert Enum.map(resp["data"]["directions"]["paths"], & &1["summary"]["length"]) == [1, 2]
+      assert resp["meta"]["include_directions"] == true
     end
   end
 
@@ -170,6 +195,14 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
       assert resp["error"]["message"] =~ "format"
     end
 
+    test "422 when include_directions is not boolean", %{conn: conn} do
+      resp =
+        conn |> submit(%{shape: @shape, include_directions: "sometimes"}) |> json_response(422)
+
+      assert resp["error"]["message"] =~ "include_directions"
+      assert resp["error"]["details"]["param"] == "include_directions"
+    end
+
     test "422 when the trace exceeds the point cap", %{conn: conn} do
       System.put_env("MAP_MATCH_MAX_POINTS", "2")
       on_exit(fn -> System.delete_env("MAP_MATCH_MAX_POINTS") end)
@@ -209,13 +242,13 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
     end
 
     test "still accepts numeric strings and integers", %{conn: conn, bypass: bypass} do
-      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+      Bypass.expect_once(bypass, "POST", "/trace_attributes", fn c ->
         {:ok, body, c} = Plug.Conn.read_body(c)
 
         assert [%{"lat" => 52.5, "lon" => 13.4}, %{"lat" => 53.0, "lon" => 14.0}] =
                  Jason.decode!(body)["shape"]
 
-        Plug.Conn.resp(c, 200, ~s({"trip":{"legs":[]}}))
+        Plug.Conn.resp(c, 200, ~s({"shape":"#{@leg_a}","edges":[],"matched_points":[]}))
       end)
 
       assert conn
@@ -227,7 +260,7 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
       conn: conn,
       bypass: bypass
     } do
-      Bypass.stub(bypass, "POST", "/trace_route", fn c ->
+      Bypass.stub(bypass, "POST", "/trace_attributes", fn c ->
         flunk("upstream must not be called for a malformed trace")
         Plug.Conn.resp(c, 200, "{}")
       end)
@@ -240,7 +273,7 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
 
   describe "upstream failures" do
     test "422 rather than 502 when the trace cannot be snapped", %{conn: conn, bypass: bypass} do
-      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+      Bypass.expect_once(bypass, "POST", "/trace_attributes", fn c ->
         Plug.Conn.resp(c, 400, ~s({"error_code":171,"error":"No suitable edges near location"}))
       end)
 
@@ -252,7 +285,7 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
     end
 
     test "502 when Valhalla errors", %{conn: conn, bypass: bypass} do
-      Bypass.expect_once(bypass, "POST", "/trace_route", fn c ->
+      Bypass.expect_once(bypass, "POST", "/trace_attributes", fn c ->
         Plug.Conn.resp(c, 500, "boom")
       end)
 
@@ -273,6 +306,23 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
       spec = conn |> get(~p"/api/v1/openapi.json") |> json_response(200)
 
       assert get_in(spec, ["paths", "/api/v1/map-match", "post", "summary"]) =~ "atch"
+      assert get_in(spec, ["paths", "/api/v1/map-match", "post", "requestBody", "required"])
+
+      point_schema =
+        get_in(spec, [
+          "paths",
+          "/api/v1/map-match",
+          "post",
+          "requestBody",
+          "content",
+          "application/json",
+          "schema",
+          "properties",
+          "shape",
+          "items"
+        ])
+
+      assert point_schema["required"] == ["lat", "lon"]
     end
   end
 end

--- a/app/swagger/v1/swagger.yaml
+++ b/app/swagger/v1/swagger.yaml
@@ -340,8 +340,10 @@ paths:
       tags:
       - Routing
       description: >-
-        Supply every optional trace field when it is available: timestamps and
-        accuracy improve matching, while trace options tune Valhalla's matcher.
+        Returns every matched segment and one correlation result per input
+        point. Supply timestamps and accuracy when available. GeoJSON uses a
+        MultiLineString when the trace contains discontinuities. Directions
+        are optional because they require a second Valhalla request.
       requestBody:
         required: true
         content:
@@ -897,6 +899,10 @@ components:
         mode: {type: string, enum: [auto, bicycle, pedestrian]}
         shape_match: {type: string, enum: [map_snap, walk_or_snap, edge_walk]}
         format: {type: string, enum: [polyline6, geojson]}
+        include_directions:
+          type: boolean
+          default: false
+          description: Include narrative paths using an additional trace_route request.
         search_radius: {type: number}
         gps_accuracy: {type: number}
         breakage_distance: {type: number}
@@ -904,21 +910,48 @@ components:
       type: object
       properties:
         data:
-          oneOf:
-          - type: object
-            properties:
-              summary: {type: object}
-              legs: {type: array, items: {type: object}}
-              shape_format: {type: string, enum: [valhalla_encoded_polyline6]}
-          - type: object
-            properties:
-              summary: {type: object}
-              geometry:
+          type: object
+          properties:
+            summary:
+              type: object
+              properties:
+                length: {type: number, description: Total matched length in kilometres}
+                time: {type: number, description: Total estimated traversal time in seconds}
+            matched_points:
+              type: array
+              items: {$ref: "#/components/schemas/MapMatchedPoint"}
+            stats: {$ref: "#/components/schemas/MapMatchStats"}
+            legs:
+              type: array
+              description: Matched segments encoded as Valhalla polyline6; present for format=polyline6.
+              items:
                 type: object
+                properties:
+                  shape: {type: string}
+                  summary: {type: object}
+            geometry:
+              description: Present for format=geojson. Discontinuous matches use MultiLineString.
+              oneOf:
+              - type: object
                 properties:
                   type: {type: string, enum: [LineString]}
                   coordinates: {type: array, items: {type: array, items: {type: number}}}
-              shape_format: {type: string, enum: [geojson]}
+              - type: object
+                properties:
+                  type: {type: string, enum: [MultiLineString]}
+                  coordinates:
+                    type: array
+                    items: {type: array, items: {type: array, items: {type: number}}}
+            segments:
+              type: array
+              description: Independently drawable GeoJSON segments; present for format=geojson.
+              items: {$ref: "#/components/schemas/MapMatchSegment"}
+            directions:
+              type: object
+              description: Present only when include_directions=true.
+              properties:
+                paths: {type: array, items: {type: object}}
+            shape_format: {type: string, enum: [valhalla_encoded_polyline6, geojson]}
         meta:
           type: object
           properties:
@@ -926,8 +959,43 @@ components:
             mode: {type: string}
             shape_match: {type: string}
             format: {type: string}
+            include_directions: {type: boolean}
             points: {type: integer}
             max_points: {type: integer}
+    MapMatchedPoint:
+      type: object
+      properties:
+        input_index: {type: integer}
+        lat: {type: number, format: double, nullable: true}
+        lon: {type: number, format: double, nullable: true}
+        type: {type: string, enum: [matched, interpolated, unmatched]}
+        edge_index: {type: integer, nullable: true}
+        distance_along_edge: {type: number, nullable: true}
+        distance_from_trace_point:
+          type: number
+          nullable: true
+          description: Distance from the recorded point to its road match in metres.
+    MapMatchStats:
+      type: object
+      properties:
+        matched: {type: integer}
+        interpolated: {type: integer}
+        unmatched: {type: integer}
+        segments: {type: integer}
+        mean_distance_from_trace_point: {type: number, nullable: true}
+        p95_distance_from_trace_point: {type: number, nullable: true}
+        max_distance_from_trace_point: {type: number, nullable: true}
+        confidence_score: {type: number, nullable: true}
+        raw_score: {type: number, nullable: true}
+    MapMatchSegment:
+      type: object
+      properties:
+        summary: {type: object}
+        geometry:
+          type: object
+          properties:
+            type: {type: string, enum: [LineString]}
+            coordinates: {type: array, items: {type: array, items: {type: number}}}
     TransitResponse:
       type: object
       properties:
@@ -1176,6 +1244,7 @@ components:
         mode: auto
         shape_match: map_snap
         format: polyline6
+        include_directions: false
         search_radius: 35
         gps_accuracy: 5
         breakage_distance: 2000
@@ -1186,17 +1255,26 @@ components:
           legs:
           - shape: _ajccB_{zpX_pR_pR
             summary: {length: 2.5, time: 300}
-            maneuvers:
-            - {type: 1, instruction: Drive east, length: 2.5, time: 300, begin_shape_index: 0, end_shape_index: 1}
+          matched_points:
+          - {input_index: 0, lat: 52.5001, lon: 13.4001, type: matched, edge_index: 0, distance_from_trace_point: 7.2}
+          - {input_index: 1, lat: 52.5099, lon: 13.4099, type: interpolated, edge_index: 4, distance_from_trace_point: 5.6}
+          stats: {matched: 1, interpolated: 1, unmatched: 0, segments: 1, mean_distance_from_trace_point: 6.4, p95_distance_from_trace_point: 7.2, max_distance_from_trace_point: 7.2, confidence_score: 1.0}
           shape_format: valhalla_encoded_polyline6
-        meta: {timestamp: '2026-09-06T20:53:10Z', mode: auto, shape_match: map_snap, format: polyline6, points: 2, max_points: 10000}
+        meta: {timestamp: '2026-09-06T20:53:10Z', mode: auto, shape_match: map_snap, format: polyline6, include_directions: false, points: 2, max_points: 10000}
     MapMatchGeoJsonResponse:
       value:
         data:
           summary: {length: 2.5, time: 300}
           geometry: {type: LineString, coordinates: [[13.4000, 52.5000], [13.4100, 52.5100]]}
+          segments:
+          - summary: {length: 2.5, time: 300}
+            geometry: {type: LineString, coordinates: [[13.4000, 52.5000], [13.4100, 52.5100]]}
+          matched_points:
+          - {input_index: 0, lat: 52.5001, lon: 13.4001, type: matched, edge_index: 0, distance_from_trace_point: 7.2}
+          - {input_index: 1, lat: 52.5099, lon: 13.4099, type: interpolated, edge_index: 4, distance_from_trace_point: 5.6}
+          stats: {matched: 1, interpolated: 1, unmatched: 0, segments: 1, mean_distance_from_trace_point: 6.4, p95_distance_from_trace_point: 7.2, max_distance_from_trace_point: 7.2, confidence_score: 1.0}
           shape_format: geojson
-        meta: {timestamp: '2026-09-06T20:53:10Z', mode: auto, shape_match: map_snap, format: geojson, points: 2, max_points: 10000}
+        meta: {timestamp: '2026-09-06T20:53:10Z', mode: auto, shape_match: map_snap, format: geojson, include_directions: false, points: 2, max_points: 10000}
     TransitResponse:
       value:
         data:


### PR DESCRIPTION
## Summary

- Use Valhalla `trace_attributes` as the canonical map-matching result and preserve every segment across trace discontinuities.
- Return one correlation result per input point, match-quality statistics, and `LineString` or `MultiLineString` GeoJSON.
- Add optional narrative directions with `include_directions=true`, including alternates, and document the expanded API in OpenAPI and the changelog.

## Why

The previous `trace_route` response could hide point-level matching quality and collapse discontinuous traces into misleading geometry. Clients need the complete match to inspect noisy GPS samples and draw each valid road segment independently.

## How to validate

- `cd app-phoenix && mix test`
- `cd app-phoenix && mix credo --strict`
- `node --test test/release_notes.test.mjs`
- Parse `app/swagger/v1/swagger.yaml` with a YAML parser.

## Risk / rollout notes

This changes the default map-match response contract: `data.legs` now represents matched segments and no longer carries route maneuvers. Clients that need maneuvers should send `include_directions=true` and consume `data.directions.paths`. No database migration is required.
