### PR TITLE
feat(map-match): reject requests above capacity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,15 +99,18 @@ WHOSONFIRST_COUNTRY_CODE=de
 # Set to False to skip SRTM download in Valhalla (saves ~3–30 GB per region).
 BUILD_ELEVATION=True
 
-# Map matching (POST /api/v1/map-match). Both are optional.
+# Map matching (POST /api/v1/map-match). All are optional.
 #
 # MAP_MATCH_MAX_POINTS: largest trace accepted in one request (default 10000).
 #   Matching is superlinear in point count and occupies a Valhalla worker for
 #   the whole request, so lower this on a shared instance.
+# MAP_MATCH_CONCURRENCY: requests admitted at once (default 4). Excess requests
+#   fail fast with HTTP 429 instead of waiting inside the HTTP/Valhalla pools.
 # VALHALLA_MATCH_TIMEOUT: milliseconds to wait for a match (default 60000).
 #   Deliberately separate from the routing timeout — a full-day trace takes
 #   far longer than an A-to-B route.
 # MAP_MATCH_MAX_POINTS=10000
+# MAP_MATCH_CONCURRENCY=4
 # VALHALLA_MATCH_TIMEOUT=60000
 
 # Transit API default; Settings persists the selected engine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 - Map matching now uses Valhalla trace attributes as its canonical result, preserves every matched segment across trace discontinuities, returns `MultiLineString` GeoJSON for segmented traces, and emits one polyline6 leg per segment.
+- Atlas admits at most four map matches at once by default and immediately returns `429 MAP_MATCH_BUSY` above that limit, preventing excess requests from occupying HTTP connections while they wait for Valhalla. `MAP_MATCH_CONCURRENCY` can tune the limit.
 
 ## [0.5.1] - 2026-09-09
 

--- a/app-phoenix/lib/atlas/application.ex
+++ b/app-phoenix/lib/atlas/application.ex
@@ -17,7 +17,8 @@ defmodule Atlas.Application do
          repos: Application.fetch_env!(:atlas, :ecto_repos), skip: skip_migrations?()},
         {DNSCluster, query: Application.get_env(:atlas, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: Atlas.PubSub},
-        {Cachex, name: :reverse_cache, expiration: expiration(default: :timer.minutes(60))}
+        {Cachex, name: :reverse_cache, expiration: expiration(default: :timer.minutes(60))},
+        Atlas.Maps.MapMatchLimiter
       ] ++ control_children() ++ [AtlasWeb.Endpoint]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/app-phoenix/lib/atlas/maps/map_match.ex
+++ b/app-phoenix/lib/atlas/maps/map_match.ex
@@ -23,7 +23,7 @@ defmodule Atlas.Maps.MapMatch do
   """
 
   alias Atlas.Geometry.Polyline
-  alias Atlas.Maps.{Result, Upstream.Client, Upstream.Valhalla}
+  alias Atlas.Maps.{MapMatchLimiter, Result, Upstream.Client, Upstream.Valhalla}
 
   require Logger
 
@@ -57,8 +57,13 @@ defmodule Atlas.Maps.MapMatch do
   def match(opts) do
     shape = opts[:shape] || []
 
-    with :ok <- validate_shape(shape),
-         {:ok, attributes} <- request_attributes(shape, opts),
+    with :ok <- validate_shape(shape) do
+      MapMatchLimiter.run(fn -> perform_match(shape, opts) end)
+    end
+  end
+
+  defp perform_match(shape, opts) do
+    with {:ok, attributes} <- request_attributes(shape, opts),
          {:ok, directions} <- request_directions(shape, opts) do
       {:ok, build_result(attributes, opts[:format], directions)}
     end

--- a/app-phoenix/lib/atlas/maps/map_match_limiter.ex
+++ b/app-phoenix/lib/atlas/maps/map_match_limiter.ex
@@ -1,0 +1,99 @@
+defmodule Atlas.Maps.MapMatchLimiter do
+  @moduledoc """
+  Fail-fast concurrency guard for Valhalla map matching.
+
+  Atlas keeps no job queue here: up to the configured number of callers hold
+  slots, and excess callers receive `{:error, :map_match_busy, limit}`. Caller
+  processes are monitored so an abnormal exit cannot leak a slot.
+  """
+
+  use GenServer
+
+  alias Atlas.Maps.Upstream.Client
+
+  @default_limit 4
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    limit = Keyword.get(opts, :limit, configured_limit())
+    start_opts = if name, do: [name: name], else: []
+
+    GenServer.start_link(__MODULE__, max(limit, 1), start_opts)
+  end
+
+  @doc "Run a function while holding one matching slot, or fail immediately."
+  def run(fun, server \\ __MODULE__) when is_function(fun, 0) do
+    case checkout(server) do
+      {:ok, token} ->
+        try do
+          fun.()
+        after
+          checkin(token, server)
+        end
+
+      busy ->
+        busy
+    end
+  end
+
+  @doc false
+  def checkout(server \\ __MODULE__), do: GenServer.call(server, {:checkout, self()})
+
+  @doc false
+  def checkin(token, server \\ __MODULE__), do: GenServer.cast(server, {:checkin, token})
+
+  @doc "Maximum number of map matches this limiter admits at once."
+  def capacity(server \\ __MODULE__), do: GenServer.call(server, :capacity)
+
+  defp configured_limit do
+    Client.env_int("MAP_MATCH_CONCURRENCY", @default_limit)
+  end
+
+  @impl true
+  def init(limit), do: {:ok, %{limit: limit, holders: %{}, monitors: %{}}}
+
+  @impl true
+  def handle_call({:checkout, pid}, _from, %{holders: holders, limit: limit} = state)
+      when map_size(holders) < limit do
+    token = make_ref()
+    monitor = Process.monitor(pid)
+
+    {:reply, {:ok, token},
+     %{
+       state
+       | holders: Map.put(holders, token, monitor),
+         monitors: Map.put(state.monitors, monitor, token)
+     }}
+  end
+
+  def handle_call({:checkout, _pid}, _from, state) do
+    {:reply, {:error, :map_match_busy, state.limit}, state}
+  end
+
+  def handle_call(:capacity, _from, state), do: {:reply, state.limit, state}
+
+  @impl true
+  def handle_cast({:checkin, token}, state), do: {:noreply, release(token, state)}
+
+  @impl true
+  def handle_info({:DOWN, monitor, :process, _pid, _reason}, state) do
+    case Map.pop(state.monitors, monitor) do
+      {nil, _monitors} ->
+        {:noreply, state}
+
+      {token, monitors} ->
+        {:noreply, %{state | holders: Map.delete(state.holders, token), monitors: monitors}}
+    end
+  end
+
+  defp release(token, state) do
+    case Map.pop(state.holders, token) do
+      {nil, _holders} ->
+        state
+
+      {monitor, holders} ->
+        Process.demonitor(monitor, [:flush])
+        %{state | holders: holders, monitors: Map.delete(state.monitors, monitor)}
+    end
+  end
+end

--- a/app-phoenix/lib/atlas_web/controllers/api/v1/fallback_controller.ex
+++ b/app-phoenix/lib/atlas_web/controllers/api/v1/fallback_controller.ex
@@ -12,6 +12,7 @@ defmodule AtlasWeb.Api.V1.FallbackController do
   - `{:error, :missing, param}` → 400 `MISSING_PARAM`
   - `{:error, :invalid, message, details}` → 422 `VALIDATION_ERROR`
   - `{:error, :too_many, max}` → 422 `VALIDATION_ERROR`
+  - `{:error, :map_match_busy, limit}` → 429 `MAP_MATCH_BUSY`
   """
   use AtlasWeb, :controller
   alias Atlas.Maps.Upstream.Client.{BadResponse, Unavailable}
@@ -35,5 +36,16 @@ defmodule AtlasWeb.Api.V1.FallbackController do
 
   def call(conn, {:error, :too_many, max}) do
     BaseController.validation_error(conn, "too many items, max #{max}", %{max: max})
+  end
+
+  def call(conn, {:error, :map_match_busy, limit}) do
+    conn
+    |> put_resp_header("retry-after", "1")
+    |> BaseController.error(
+      :too_many_requests,
+      "MAP_MATCH_BUSY",
+      "map matching is at capacity; retry later",
+      %{limit: limit}
+    )
   end
 end

--- a/app-phoenix/lib/atlas_web/controllers/api/v1/map_match_controller.ex
+++ b/app-phoenix/lib/atlas_web/controllers/api/v1/map_match_controller.ex
@@ -64,6 +64,7 @@ defmodule AtlasWeb.Api.V1.MapMatchController do
     responses: %{
       200 => response("Matched trace", "application/json", Schemas.Response),
       400 => response("Missing shape", "application/json", Schemas.Error),
+      429 => response("Map matching capacity reached", "application/json", Schemas.Error),
       422 => response("Invalid or unmatchable trace", "application/json", Schemas.Error),
       502 => response("Upstream error", "application/json", Schemas.Error),
       503 => response("Upstream unavailable", "application/json", Schemas.Error)

--- a/app-phoenix/test/atlas/maps/map_match_limiter_test.exs
+++ b/app-phoenix/test/atlas/maps/map_match_limiter_test.exs
@@ -1,0 +1,49 @@
+defmodule Atlas.Maps.MapMatchLimiterTest do
+  use ExUnit.Case, async: true
+
+  alias Atlas.Maps.MapMatchLimiter
+
+  test "fails fast at capacity and admits work after checkin" do
+    limiter = start_supervised!({MapMatchLimiter, name: nil, limit: 1})
+
+    assert {:ok, token} = MapMatchLimiter.checkout(limiter)
+    assert {:error, :map_match_busy, 1} = MapMatchLimiter.run(fn -> :unexpected end, limiter)
+
+    MapMatchLimiter.checkin(token, limiter)
+    assert MapMatchLimiter.run(fn -> :matched end, limiter) == :matched
+  end
+
+  test "reclaims a slot when its caller exits" do
+    limiter = start_supervised!({MapMatchLimiter, name: nil, limit: 1})
+    parent = self()
+
+    holder =
+      spawn(fn ->
+        result = MapMatchLimiter.checkout(limiter)
+        send(parent, {:slot_held, result})
+        if match?({:ok, _token}, result), do: Process.sleep(:infinity)
+      end)
+
+    assert_receive {:slot_held, {:ok, _token}}
+    assert {:error, :map_match_busy, 1} = MapMatchLimiter.checkout(limiter)
+
+    Process.exit(holder, :kill)
+    assert eventually_checkout(limiter)
+  end
+
+  defp eventually_checkout(limiter, attempts \\ 20)
+
+  defp eventually_checkout(_limiter, 0), do: false
+
+  defp eventually_checkout(limiter, attempts) do
+    case MapMatchLimiter.checkout(limiter) do
+      {:ok, token} ->
+        MapMatchLimiter.checkin(token, limiter)
+        true
+
+      {:error, :map_match_busy, 1} ->
+        Process.sleep(1)
+        eventually_checkout(limiter, attempts - 1)
+    end
+  end
+end

--- a/app-phoenix/test/atlas_web/controllers/api/v1/map_match_controller_test.exs
+++ b/app-phoenix/test/atlas_web/controllers/api/v1/map_match_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
   use AtlasWeb.ConnCase, async: false
 
-  alias Atlas.Maps.MapMatch
+  alias Atlas.Maps.{MapMatch, MapMatchLimiter}
 
   # Decodes to [{52.5, 13.4}, {52.51, 13.41}] at precision 6.
   @leg_a "_ajccB_{zpX_pR_pR"
@@ -272,6 +272,23 @@ defmodule AtlasWeb.Api.V1.MapMatchControllerTest do
   end
 
   describe "upstream failures" do
+    test "429 when all map matching slots are occupied", %{conn: conn} do
+      tokens =
+        for _ <- 1..MapMatchLimiter.capacity() do
+          {:ok, token} = MapMatchLimiter.checkout()
+          token
+        end
+
+      on_exit(fn -> Enum.each(tokens, &MapMatchLimiter.checkin/1) end)
+
+      conn = submit(conn, %{shape: @shape})
+      resp = json_response(conn, 429)
+
+      assert resp["error"]["code"] == "MAP_MATCH_BUSY"
+      assert resp["error"]["details"]["limit"] == MapMatchLimiter.capacity()
+      assert get_resp_header(conn, "retry-after") == ["1"]
+    end
+
     test "422 rather than 502 when the trace cannot be snapped", %{conn: conn, bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/trace_attributes", fn c ->
         Plug.Conn.resp(c, 400, ~s({"error_code":171,"error":"No suitable edges near location"}))

--- a/app/swagger/v1/swagger.yaml
+++ b/app/swagger/v1/swagger.yaml
@@ -377,6 +377,16 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ErrorEnvelope"
+        '429':
+          description: map matching capacity reached; retry later
+          headers:
+            Retry-After:
+              schema: {type: integer}
+              description: Suggested delay in seconds before retrying.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorEnvelope"
   "/api/v1/transit":
     get:
       summary: Plan a public-transport journey

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -66,6 +66,7 @@ services:
       # reaches the app — this service passes an explicit allowlist, not
       # env_file, so an undeclared variable is silently dropped.
       MAP_MATCH_MAX_POINTS: ${MAP_MATCH_MAX_POINTS:-}
+      MAP_MATCH_CONCURRENCY: ${MAP_MATCH_CONCURRENCY:-4}
       VALHALLA_MATCH_TIMEOUT: ${VALHALLA_MATCH_TIMEOUT:-}
       OVERPASS_URL: http://overpass:80
       OTP_URL: http://otp:8080

--- a/compose.dokploy.yml
+++ b/compose.dokploy.yml
@@ -122,6 +122,7 @@ services:
       # reaches the app — this service passes an explicit allowlist, not
       # env_file, so an undeclared variable is silently dropped.
       MAP_MATCH_MAX_POINTS: ${MAP_MATCH_MAX_POINTS:-}
+      MAP_MATCH_CONCURRENCY: ${MAP_MATCH_CONCURRENCY:-4}
       VALHALLA_MATCH_TIMEOUT: ${VALHALLA_MATCH_TIMEOUT:-}
       OVERPASS_URL: http://overpass:80
       OTP_URL: ${OTP_URL:-http://otp:8080}

--- a/compose.yml
+++ b/compose.yml
@@ -50,6 +50,7 @@ services:
       # reaches the app — this service passes an explicit allowlist, not
       # env_file, so an undeclared variable is silently dropped.
       MAP_MATCH_MAX_POINTS: ${MAP_MATCH_MAX_POINTS:-}
+      MAP_MATCH_CONCURRENCY: ${MAP_MATCH_CONCURRENCY:-4}
       VALHALLA_MATCH_TIMEOUT: ${VALHALLA_MATCH_TIMEOUT:-}
       OVERPASS_URL: http://overpass:80
       OTP_URL: http://otp:8080


### PR DESCRIPTION
## Summary

- Admit at most four synchronous map-matching requests at once by default, with `MAP_MATCH_CONCURRENCY` available for tuning.
- Return `429 MAP_MATCH_BUSY` and `Retry-After` immediately when capacity is full instead of building an implicit HTTP backlog.
- Monitor slot owners so completed, failed, or terminated request processes always release capacity.

## Why

Valhalla map matching is CPU intensive and holds a server worker for the full trace. A burst of requests should leave Atlas responsive without introducing a persistent job queue for the MVP.

## How to validate

- `cd app-phoenix && mix test` — 778 tests, 0 failures, 1 skipped.
- `cd app-phoenix && mix credo --strict`
- `node --test test/release_notes.test.mjs test/deployment_config.test.mjs`
- Parse `app/swagger/v1/swagger.yaml` and validate all three Compose configurations.

## Risk / rollout notes

The default limit matches the four Valhalla server threads shipped by Atlas. Existing single-request behavior is unchanged. Clients receiving 429 should retry with backoff; operators with a different Valhalla worker count can set `MAP_MATCH_CONCURRENCY` and restart Atlas.
